### PR TITLE
Allow translators to define hidden preferences

### DIFF
--- a/src/bookmarklet/translator.js
+++ b/src/bookmarklet/translator.js
@@ -344,7 +344,7 @@ Zotero.Translators.CodeGetter.prototype.getCodeFor = function(i) {
 var TRANSLATOR_REQUIRED_PROPERTIES = ["translatorID", "translatorType", "label", "creator", "target",
 		"priority", "lastUpdated"];
 var TRANSLATOR_PASSING_PROPERTIES = TRANSLATOR_REQUIRED_PROPERTIES.concat(["displayOptions", "configOptions",
-		"browserSupport", "code", "runMode"]);
+		"hiddenPrefs", "browserSupport", "code", "runMode"]);
 var TRANSLATOR_SAVE_PROPERTIES = TRANSLATOR_REQUIRED_PROPERTIES.concat(["browserSupport"]);
 /**
  * @class Represents an individual translator
@@ -362,8 +362,11 @@ var TRANSLATOR_SAVE_PROPERTIES = TRANSLATOR_REQUIRED_PROPERTIES.concat(["browser
  *     c = Google Chrome (WebKit & V8)
  *     s = Safari (WebKit & Nitro/Squirrelfish Extreme)
  *     i = Internet Explorer
+ *     b = Bookmarklet
+ *     v = Server (requires server translation when using a bookmarklet)
  * @property {Object} configOptions Configuration options for import/export
  * @property {Object} displayOptions Display options for export
+ * @property {Object} hiddenPrefs Hidden preferences configurable through about:config
  * @property {Boolean} inRepository Whether the translator may be found in the repository
  * @property {String} lastUpdated SQL-style date and time of translator's last update
  * @property {String} code The executable JavaScript for the translator
@@ -400,7 +403,16 @@ Zotero.Translator.prototype.init = function(info) {
 	
 	this.configOptions = info["configOptions"] ? info["configOptions"] : {};
 	this.displayOptions = info["displayOptions"] ? info["displayOptions"] : {};
-	
+	if(info.hiddenPrefs) {
+		//check for key
+		if(typeof(info.hiddenPrefs.prefs) == "object" && !info.hiddenPrefs.key) {
+			throw(new Error("'key' must be defined when declaring hiddenPrefs in " + info.label));
+		}
+		this._hiddenPrefs = info.hiddenPrefs;
+	} else {
+		this._hiddenPrefs = {};
+	}
+
 	if(this.translatorType & TRANSLATOR_TYPES["import"]) {
 		// compile import regexp to match only file extension
 		this.importRegexp = this.target ? new RegExp("\\."+this.target+"$", "i") : null;


### PR DESCRIPTION
This goes along with zotero/zotero#223

I don't think there's a way for users to define these preferences atm with Connectors or Bookmarklet (I saw that preferences are stored in HTML5 localStorage, but I don't think we provide any way to edit it). Either way, this will at least make the default hiddenPrefs values available to translators.

Perhaps we should be fetching preferences from Zotero Standalone in Connectors (and bookmarklet?) It's a bit of an overhead, though communication over loopback interface should be fairly fast.

Also, there are no `__defineGetter__` declarations for displayOptions or configOptions. I get that displayOptions is not used in connectors, but I thought configOptions would be. Do we not need to deepCopy these in connectors? Let me know if we do, then I'll add it in.
