### PR TITLE
Align connector detectWeb rules with Firefox

### DIFF
--- a/src/chrome/background.js
+++ b/src/chrome/background.js
@@ -34,8 +34,25 @@ Zotero.Connector_Browser = new function() {
 	 */
 	this.onTranslators = function(translators, instanceID, tab) {
 		var oldTranslators = _translatorsForTabIDs[tab.id];
-		if(oldTranslators && oldTranslators.length
-			&& (!translators.length || oldTranslators[0].priority <= translators[0].priority)) return;
+		if(//we already have a translator for part of this page
+			oldTranslators && oldTranslators.length //&& oldTranslators.targetURL copied from Firefox, but I don't think it's relevant
+			//and the page is still there (not as easy to check in Chrome/Safari)
+			//&& this.page.document.defaultView && !this.page.document.defaultView.closed
+			//this set of translators is not targeting the same URL as a previous set of translators,
+			// because otherwise we want to use the newer set
+			&& oldTranslators.targetURL != translators.targetURL
+				//the best translator we had was of higher priority than the new set
+			&& (oldTranslators.bestPriority < translators.bestPriority
+				//or the priority was the same, but...
+				|| (oldTranslators.bestPriority == translators.bestPriority
+					//the previous set of translators targets the top frame or the current one does not either
+					&& (oldTranslators.targetsTopFrame || !translators.targetsTopFrame)
+				)
+			)
+		) {
+			return; //keep what we had
+		}
+		
 		_translatorsForTabIDs[tab.id] = translators;
 		_instanceIDsForTabs[tab.id] = instanceID;
 		var itemType = translators[0].itemType;

--- a/src/common/inject/inject.js
+++ b/src/common/inject/inject.js
@@ -157,7 +157,12 @@ Zotero.Inject = new function() {
 				_translate.setHandler("translators", function(obj, translators) {
 					if(translators.length) {
 						me.translators = translators;
+						translators.targetURL = document.location.href;
+						translators.targetsTopFrame = isTopWindow;
 						for(var i=0; i<translators.length; i++) {
+							translators.bestPriority = translators[0].priority;
+							
+							// Safari has issues cloning functions, so strip them off
 							if(translators[i].properToProxy) {
 								delete translators[i].properToProxy;
 							}

--- a/src/safari/global.html
+++ b/src/safari/global.html
@@ -44,9 +44,26 @@ Zotero.Connector_Browser = new function() {
 	 * Called when translators are available for a given page
 	 */
 	this.onTranslators = function(translators, instanceID, tab) {
-		// if we already have translators for this page, return
-		if(tab.translators && tab.translators.length
-			&& (!translators.length || tab.translators[0].priority <= translators[0].priority)) return;
+		var oldTranslators = tab.translators;
+		if(//we already have a translator for part of this page
+			oldTranslators && oldTranslators.length //&& oldTranslators.targetURL copied from Firefox, but I don't think it's relevant
+			//and the page is still there (not as easy to check in Chrome/Safari)
+			//&& this.page.document.defaultView && !this.page.document.defaultView.closed
+			//this set of translators is not targeting the same URL as a previous set of translators,
+			// because otherwise we want to use the newer set
+			&& oldTranslators.targetURL != translators.targetURL
+				//the best translator we had was of higher priority than the new set
+			&& (oldTranslators.bestPriority < translators.bestPriority
+				//or the priority was the same, but...
+				|| (oldTranslators.bestPriority == translators.bestPriority
+					//the previous set of translators targets the top frame or the current one does not either
+					&& (oldTranslators.targetsTopFrame || !translators.targetsTopFrame)
+				)
+			)
+		) {
+			return; //keep what we had
+		}
+		
 		tab.instanceID = instanceID;
 		tab.translators = translators;
 		tab.translatorsForURL = tab.url;


### PR DESCRIPTION
Chrome connector seems to like this. I'm having a bit of a hard time finding test cases atm (some of the pages that were reported don't seem to have embedded iframes anymore), but reverting https://github.com/zotero/translators/commit/2ca80898871b5039cf25c330859ee195885e11bc and navigating to http://www.forbes.com/sites/peterlipson/2013/04/19/a-film-producer-a-cancer-doctor-and-their-critics/ doesn't work on the current connector, but does with this patch

I haven't tested Safari connector.
