### PR TITLE
Set "pageModified" handler and clear URL bar icon when fired

### DIFF
--- a/src/chrome/background.js
+++ b/src/chrome/background.js
@@ -112,6 +112,7 @@ Zotero.Connector_Browser = new function() {
 		delete _translatorsForTabIDs[tabID];
 		delete _instanceIDsForTabs[tabID];
 		delete _selectCallbacksForTabIDs[tabID];
+		chrome.pageAction.hide(tabID);
 	}
 
 	Zotero.Messaging.addMessageListener("selectDone", function(data) {

--- a/src/common/inject/inject.js
+++ b/src/common/inject/inject.js
@@ -154,6 +154,9 @@ Zotero.Inject = new function() {
 					Zotero.Connector_Browser.onTranslators(translators, instanceID);
 				}
 			});
+			_translate.setHandler("pageModified", function(translate, doc) {
+				Zotero.Messaging.sendMessage("pageModified", null)
+			});
 			_translate.setHandler("select", function(obj, items, callback) {
 				Zotero.Connector_Browser.onSelect(items, function(returnItems) {
 					// if no items selected, close save dialog immediately

--- a/src/safari/global.html
+++ b/src/safari/global.html
@@ -37,6 +37,7 @@ Zotero.Connector_Browser = new function() {
 		if(tab.translators) {
 			tab.translators = [];
 		}
+		_updateButtonStatus();
 	}
 	
 	/**


### PR DESCRIPTION
Not sure how this ever worked when #5 was being tested (though I'm fairly sure it did). Nonetheless, this fixes monitorDOMChanges in Chrome and should fix it in Safari, though I don't have v6.0+ to test on.
