### PR TITLE
Don't throw onPageLoad errors when triggered from Chrome's internals

### DIFF
--- a/src/chrome/background.js
+++ b/src/chrome/background.js
@@ -72,7 +72,7 @@ Zotero.Connector_Browser = new function() {
 	 * Called when a tab is removed or the URL has changed
 	 */
 	this.onPageLoad = function(tab) {
-		_clearInfoForTab(tab.id);
+		if(tab) _clearInfoForTab(tab.id);
 	}
 	
 	/**


### PR DESCRIPTION
When Google Chrome's "Use a prediction service to help complete searches and URLs typed in the address bar" is selected, Chrome appears to always load an https://www.google.com/webhp?... page somewhere in the background. This triggers Zotero's onPageLoad handler, but since the page is not loaded in a tab, it does not pass a tab object.

Re https://forums.zotero.org/discussion/33837/ams-mathscinet-and-euclid-translators-not-working/#Item_9
