### PR TITLE
Fixes for monitorDOMChanges

### DIFF
--- a/src/chrome/background.js
+++ b/src/chrome/background.js
@@ -112,6 +112,7 @@ Zotero.Connector_Browser = new function() {
 		delete _translatorsForTabIDs[tabID];
 		delete _instanceIDsForTabs[tabID];
 		delete _selectCallbacksForTabIDs[tabID];
+		chrome.pageAction.hide(tabID);
 	}
 
 	Zotero.Messaging.addMessageListener("selectDone", function(data) {
@@ -120,9 +121,12 @@ Zotero.Connector_Browser = new function() {
 
 	chrome.tabs.onRemoved.addListener(_clearInfoForTab);
 
-	chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+	chrome.tabs.onUpdated.addListener(function(tabID, changeInfo, tab) {
+		// Rerun translation if a tab's URL changes
 		if(!changeInfo.url) return;
-		chrome.tabs.sendRequest(tabId, ["pageModified"], null);
+		Zotero.debug("Connector_Browser: URL changed for tab");
+		_clearInfoForTab(tabID);
+		chrome.tabs.sendRequest(tabID, ["pageModified"], null);
 	});
 
 	chrome.pageAction.onClicked.addListener(function(tab) {

--- a/src/safari/global.html
+++ b/src/safari/global.html
@@ -37,6 +37,7 @@ Zotero.Connector_Browser = new function() {
 		if(tab.translators) {
 			tab.translators = [];
 		}
+		_updateButtonStatus();
 	}
 	
 	/**


### PR DESCRIPTION
- Dispatch pageModified event (to all frames in tab) on a DOM change.
- Clear translators for a tab before running any detection. In particular, ensure we don't clear valid translators for one frame when we run detection on another frame.
- Avoid re-creating Zotero.Translate instance when handling pageModified event. This also avoids dangling MutationObservers in a case where we have multiple MutationObservers and only one fires.

I tested this on ARTstor and it seems to behave as expected. @aurimasv, please make sure this looks right to you too.
