### PR TITLE
Add keyboard shortcut for scraping page in Chrome.

### DIFF
--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -36,5 +36,12 @@
 		"128": "Icon-128.png"
 	},
 	"options_page": "preferences/preferences.html",
-	"update_url": "https://www.zotero.org/download/everywhere/chrome/update.xml"
+	"update_url": "https://www.zotero.org/download/everywhere/chrome/update.xml",
+	"commands": {
+		"_execute_page_action": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+S"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Matches https://github.com/zotero/zotero/commit/dc8998c5bc1e582173420efae7647c3add82d62c
Note that on Mac "Ctrl" is treated as "Command"

I can't find decent documentation on how to do this in Safari (I also don't have as much incentive, since I don't use it)
