### PR TITLE
Fix possible benign error message in Chrome

### DIFF
--- a/src/chrome/messaging_inject.js
+++ b/src/chrome/messaging_inject.js
@@ -75,7 +75,7 @@ Zotero.Messaging = new function() {
 									if(messageConfig.postReceive) {
 										response = messageConfig.postReceive.apply(null, response);
 									}
-									callback.apply(null, response);
+									if (callback) callback.apply(null, response);
 								} catch(e) {
 									Zotero.logError(e);
 								}


### PR DESCRIPTION
Not exactly sure why this wasn't triggering all the time, but it was reported in the screenshot here: https://forums.zotero.org/discussion/43192/zotero-chrome-does-not-complete-loading-google-book-data/