### PR TITLE
Return `false` when canceling multiples selection dialog

### DIFF
--- a/src/common/itemSelector/itemSelector.js
+++ b/src/common/itemSelector/itemSelector.js
@@ -79,13 +79,15 @@ function load() {
  * Called when the "OK" button is pressed to save selected items
  */
 function ok() {
-	var newItems = {};
+	var newItems = {},
+		selected = false;
 	for(var i in checkboxes) {
 		if(checkboxes[i].checked) {
+			selected = true;
 			newItems[i] = items[i];
 		}
 	}
-	items = newItems;
+	items = selected && newItems;
 	sendMessage();
 }
 

--- a/src/common/itemSelector/itemSelector.js
+++ b/src/common/itemSelector/itemSelector.js
@@ -93,7 +93,7 @@ function ok() {
  * Called when the "Cancel" button is pressed
  */
 function cancel() {
-	items = {};
+	items = false;
 	sendMessage();
 }
 


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/49763

(edit: nvm, I tested it and this does fix it)

I suppose generally this wouldn't matter. WoS seems to export all results if no result IDs are supplied though.