### PR TITLE
Firefox XUL -> WebExtensions communication

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -195,7 +195,11 @@ Zotero.Connector_Browser = new function() {
 		}
 		return Zotero.Promise.all(promises);
 	};
-	
+
+	this.openTab = function(url) {
+		chrome.tabs.create({url});
+	};
+
 	/**
 	 * Update status and tooltip of Zotero button
 	 */

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -225,9 +225,6 @@ Zotero.API = new function() {
 	 */
 	this.createItem = function(payload, callback, askForAuth) {
 		Zotero.API.getUserInfo(function(userInfo) {
-			var userID = localStorage["auth-userID"],
-				apiKey = localStorage["auth-token_secret"];
-			
 			if(!userInfo) {
 				if(askForAuth === false) {
 					callback(403, "Not authorized");

--- a/src/common/inject/inject.jsx
+++ b/src/common/inject/inject.jsx
@@ -241,7 +241,7 @@ Zotero.Inject = new function() {
 						if (proceed) {
 							Zotero.Prefs.set('firstSaveToServer', false);
 						}
-						return proceed
+						return proceed;
 					});
 				}
 				return true;

--- a/src/common/inject/inject.jsx
+++ b/src/common/inject/inject.jsx
@@ -189,7 +189,7 @@ Zotero.Inject = new function() {
 				/>
 			);
 			function onClose(state, event) {
-				deferred.resolve({button: event.target.name,
+				deferred.resolve({button: parseInt(event.target.name || 0),
 					checkboxChecked: state.checkboxChecked,
 					inputText: state.inputText
 				});
@@ -203,15 +203,55 @@ Zotero.Inject = new function() {
 		return deferred.promise;	
 	};
 	
+	this.firstSaveToServerPrompt = function() {
+		return this.confirm({
+			checkbox: true,
+			checkboxBlock: true,
+			checkboxText: "I want to save directly to zotero.org",
+			button3Text: "More Information…",
+			title: `Saving to zotero.org`,
+			message: `
+				The Zotero Connector cannot communicate with Zotero on your computer. The Zotero Connector can save some pages directly to your zotero.org account, but for best results you should make sure Zotero is open before attempting to save.<br/><br/>
+				You can <a href="https://www.zotero.org/download/">download Zotero</a> or <a href="https://www.zotero.org/support/kb/connector_zotero_unavailable">troubleshoot the connection</a> if necessary.
+
+			`
+		}).then(function(result) {
+			if (result.button == 3) {
+				Zotero.Connector_Browser.openTab('https://www.zotero.org/support/save_to_zotero_org');
+			}
+			return result.button == 1;
+		});
+	};
+	
 	/**
-	 * Translates this page. First, retrieves schema and preferences from global script, then
-	 * passes them off to _haveSchemaAndPrefs
+	 * Translates this page.
+	 * Checks if Zotero is unavailable and prompts about saving to zotero.org if first time
 	 */
 	this.translate = function(translatorID) {
-		// this relays an item from this tab to the top level of the window
-		Zotero.Messaging.sendMessage("progressWindow.show", null);
-		_translate.setTranslator(this.translators[translatorID]);
-		_translate.translate();
+		Zotero.Connector.checkIsOnline(function(status) {
+			new Zotero.Promise(function(resolve) {
+				if (!status) {
+					resolve(Zotero.Prefs.getAsync('firstSaveToServer'));
+				} else {
+					resolve(false);
+				}
+			}).then(function(firstSaveToServer) {
+				if (firstSaveToServer) {
+					return Zotero.Inject.firstSaveToServerPrompt().then(function(proceed) {
+						if (proceed) {
+							Zotero.Prefs.set('firstSaveToServer', false);
+						}
+						return proceed
+					});
+				}
+				return true;
+			}).then(function(proceed) {
+				if (!proceed) return;
+				Zotero.Messaging.sendMessage("progressWindow.show", null);
+				_translate.setTranslator(Zotero.Inject.translators[translatorID]);
+				_translate.translate();
+			})
+		});
 	};
 	
 	/**

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -121,6 +121,8 @@ var MESSAGES = {
 			onPageLoad: false,
 			onTranslators: false,
 			injectScripts: true,
+			firstSaveToServerPrompt: true,
+			openTab: false
 		},
 	Connector_Debug: 
 		{

--- a/src/common/messaging.js
+++ b/src/common/messaging.js
@@ -53,6 +53,9 @@ Zotero.Messaging = new function() {
 	this.receiveMessage = function(messageName, args, sendResponseCallback, tab, frameId) {
 		try {
 			//Zotero.debug("Messaging: Received message: "+messageName);
+			if (!Array.isArray(args)) {
+				args = [args];
+			}
 			
 			// first see if there is a message listener
 			if(_messageListeners[messageName]) {

--- a/src/common/ui/modal-prompt.jsx
+++ b/src/common/ui/modal-prompt.jsx
@@ -66,13 +66,17 @@ Zotero.ui.ModalPrompt = React.createClass({
 		 * This is required because the component does not know how to remove itself from the DOM.
 		 */
 		onClose: React.PropTypes.func.isRequired,
-		onButton1: React.PropTypes.func,
 		/**
-		 * Triggered on clicking button2. Defaults to onClose
+		 * Triggered on clicking a button. Defaults to onClose
 		 * @default onClose
 		 */
-		onButton2: React.PropTypes.func,
-		onButton3: React.PropTypes.func,
+		onButton: React.PropTypes.func,
+		/**
+		 * The body of the prompt to be displayed. Can be a react element or a html string.
+		 * Newlines are NOT converted into <br/>
+		 */
+		message: React.PropTypes.any,
+		children: React.PropTypes.any
 	},
 
 	getInitialState: function() {
@@ -186,7 +190,7 @@ Zotero.ui.ModalPrompt = React.createClass({
 				padding: "16px",
 				fontSize: "16px", fontFamily: "Tahoma, Geneva, sans-serif"
 			}}>
-				<h2 className="popup-title">{this.props.title}</h2>
+				<h2 style={{marginTop: 0}} className="popup-title">{this.props.title}</h2>
 				<p className="popup-body">{message}</p>
 				{checkbox}
 				{input}

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -42,17 +42,18 @@ var Zotero = new function() {
 	this.isChrome = window.navigator.userAgent.indexOf("Chrome") !== -1 || window.navigator.userAgent.indexOf("Chromium") !== -1;
 	this.isBrowserExt = this.isFirefox || this.isEdge || this.isChrome;
 
-	if(this.isFirefox) {
+	if (this.isFirefox) {
 		this.browser = "g";
 		this.clientName = 'Firefox Connector';
-	} else if(this.isSafari) {
+	} else if (this.isSafari) {
 		this.browser = "s";
 		this.clientName = 'Safari Connector';
-	} else if(this.isIE) {
+	} else if (this.isIE) {
 		this.browser = "i";
+		this.clientName = 'Internet Explorer'; // ?? Property unlikely to be used, but it is IE.
 	} else {
-		this.clientName = 'Chrome Connector';
 		this.browser = "c";
+		this.clientName = 'Chrome Connector';
 	}
 	
 	if (this.isBrowserExt) {
@@ -190,6 +191,7 @@ Zotero.Prefs = new function() {
 		"capitalizeTitles": false,
 		"interceptKnownFileTypes": true,
 		"allowedInterceptHosts": [],
+		"firstSaveToServer": true,
 		
 		"proxies.transparent": true,
 		"proxies.autoRecognize": true,

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -73,6 +73,9 @@ var Zotero = new function() {
 		Zotero.Messaging.init();
 		Zotero.Connector_Types.init();
 		Zotero.Repo.init();
+		
+		Zotero.promptFxConnectorMigration();
+		Zotero.Prefs.set('previousConnectorVersion', Zotero.version);
 	};
 	
 	/**
@@ -84,6 +87,12 @@ var Zotero = new function() {
 		Zotero.Messaging.init();
 		Zotero.Connector_Types.init();
 	};
+	
+	
+	this.promptFxConnectorMigration = function() {
+		if (Zotero.Prefs.get('previousConnectorVersion') >= "5" || !Zotero.isFirefox) return;
+		Zotero.Connector_Browser.openTab('https://www.zotero.org/support/zotero_for_firefox_migration');
+	}
 	
 	
 	/**
@@ -191,6 +200,7 @@ Zotero.Prefs = new function() {
 		"capitalizeTitles": false,
 		"interceptKnownFileTypes": true,
 		"allowedInterceptHosts": [],
+		"previousConnectorVersion": "0",
 		"firstSaveToServer": true,
 		
 		"proxies.transparent": true,


### PR DESCRIPTION
Closes #48.

On first install on Firefox [opens a page](https://docs.google.com/document/d/1hpdF7jOvuzywv_E_V12Q07YrJ-5ZC0dW8PQlk6ExRm0/edit#heading=h.v6sp0luaepot)

On first attempt to translate, if Zotero not open, displays a prompt (OK disabled until checkbox is checked):
![image](https://cloud.githubusercontent.com/assets/5899315/21591618/7d633fd6-d10e-11e6-881d-d2ee88a7c9a7.png)
[More Info...](https://docs.google.com/document/d/1KBvSEXzrD1wywmhe_aZ4VL2xPldZwrfpWtQkbxwSAuQ/edit#heading=h.d6ig5rxbu9mb)

-------------

The functionality is there, the copy is not. We need to move it out of docs and onto zotero.org somewhere, along with someone doing an edit.