### PR TITLE
Prompt with additional details for new proxy

### DIFF
--- a/src/common/messaging.js
+++ b/src/common/messaging.js
@@ -113,6 +113,11 @@ Zotero.Messaging = new function() {
 		}
 		// Use the promise or response callback in BrowserExt for advanced functionality
 		else if(Zotero.isBrowserExt) {
+			// Get current tab if not provided
+			if (!tab) return new Zotero.Promise(function(resolve) {
+				chrome.tabs.query({active: true, lastFocusedWindow: true},
+					(tabs) => resolve(this.sendMessage(messageName, args, tabs[0], frameId)));
+			}.bind(this));
 			// Firefox returns a promise
 			if (Zotero.isFirefox) {
 				// Firefox throws an error when the receiving end doesn't exist (e.g. before injection)
@@ -125,6 +130,8 @@ Zotero.Messaging = new function() {
 				return deferred.promise;
 			}
 		} else if(Zotero.isSafari) {
+			// Use current tab if not provided
+			tab = tab || safari.application.activeBrowserWindow.activeTab;
 			tab.page.dispatchMessage(messageName, args);
 		}
 	}

--- a/src/common/proxy.js
+++ b/src/common/proxy.js
@@ -148,12 +148,26 @@ Zotero.Proxies = new function() {
 				null
 			)
 			.then(function(response) {
-				if (response == 2) Zotero.Proxies.save(proxy);
+				if (response == 2) {
+					return Zotero.Messaging.sendMessage('confirm', {
+						title: 'Only add proxies linked from your library, school, or corporate website',
+						message: 'Adding other proxies allows malicious sites to masquarade as sites you trust.<br/></br>'
+							+ 'Adding this proxy will allow Zotero to recognize items from its pages and will automatically '
+							+ `redirect future requests to ${proxy.hosts[proxy.hosts.length-1]} through ${proxiedHost}.`,
+						button1Text: 'Add Proxy',
+						button2Text: 'Ignore'
+					}).then(function(result) {
+						if (result.button == 1) {
+							return Zotero.Proxies.save(proxy);
+						}
+					});
+				}
 				if (response == 1) {
 					Zotero.Connector_Browser.openPreferences("proxies");
 					// This is a bit of a hack.
 					// Technically the notification can take an onClick handler, but we cannot
 					// pass functions from background to content scripts easily
+					// so to "keep the notification open" we display it agian
 					notifyNewProxy(proxy, proxiedHost);
 				}
 			});


### PR DESCRIPTION
Closes #128 

Z4.0 prompt:
<img width="547" alt="warning" src="https://cloud.githubusercontent.com/assets/783082/26091553/eb4521f2-39d9-11e7-858f-30fc0f67103c.png">

New prompt:
<img width="547" alt="warning" src="https://cloud.githubusercontent.com/assets/5899315/26105040/258f7f3c-3a49-11e7-94f0-fe1a06e7d53f.png">

I think we need Zotero branding on the prompts.