### PR TITLE
fix segment fault during convert

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -212,8 +212,12 @@ if [ $RETVAL == 0 ]; then
 	cp $IMAGES $PREFS_IMAGES "$BUILD_DIR/safari.safariextension/images"
 	for f in $ICONS
 	do
-		convert $f -background white -flatten -negate -alpha Background -alpha Copy -channel \
+		{
+			convert $f -background white -flatten -negate -alpha Background -alpha Copy -channel \
+				Opacity -contrast-stretch 50 "$BUILD_DIR/safari.safariextension/images/toolbar/"`basename $f` ||
+			convert $f -background white -negate -alpha Background -alpha Copy -channel \
 				Opacity -contrast-stretch 50 "$BUILD_DIR/safari.safariextension/images/toolbar/"`basename $f`
+		} 2>/dev/null
 	done
 else
 	echo


### PR DESCRIPTION
On Archlinux with gcc 7.2.0-3 and imagemagick 6.9.9.22-1
I get segment fault when converting `src/zotero/chrome/skin/default/zotero/treeitem@2x.png` to `build/safari.safariextension/images/toolbar/treeitem@2x.png`
I removed the `-flatten` flags and it works now. The converted icon is
![treeitem 2x](https://user-images.githubusercontent.com/5357170/32834680-677e1dec-ca3e-11e7-8dce-95bac9719f1d.png)
(PS. it's almost transparent)

Is the converted icon correct?

And I created this PR to try to convert with the `-flatten` flags then without it.