### PR TITLE
Google Docs Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = src/zotero
 	url = git://github.com/zotero/zotero.git
 	branch = master
+
+[submodule "src/zotero-google-docs-integration"]
+	path = src/zotero-google-docs-integration
+	url = git://github.com/zotero/zotero-google-docs-integration.git

--- a/build.sh
+++ b/build.sh
@@ -297,6 +297,10 @@ function copyResources {
 		"$EXTENSION_XPCOM_DIR/translation/translator.js" \
 		"$EXTENSION_XPCOM_DIR/translation/tlds.js" \
 		"$browser_builddir/zotero/translation"
+		
+	# Copy google docs integration code
+	cp -r "$SRCDIR/zotero-google-docs-integration/src/connector" \
+		 "$browser_builddir/zotero-google-docs-integration"
 	
 	# Copy node_modules libs
 	mkdir "$browser_builddir/lib"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,16 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -1084,9 +1094,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1120,6 +1130,7 @@
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1141,7 +1152,6 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -2962,14 +2972,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2978,6 +2980,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3460,6 +3470,12 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
         }
       }
     },
@@ -3741,10 +3757,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -4065,16 +4081,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -4582,6 +4588,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -4589,7 +4596,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.3.3",
@@ -4698,7 +4704,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "4.3.6",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -5490,9 +5496,9 @@
       }
     },
     "semver": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "sequencify": {
@@ -5703,15 +5709,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5721,6 +5718,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -79,44 +79,18 @@ Zotero.Connector_Browser = new function() {
 	/**
 	 * Called to display select items dialog
 	 */
-	this.onSelect = function(items, tab) {
-		var width, height, left, top;
-		return browser.windows.get(tab.windowId, null).then(function (win) {
-			width = 600;
-			height = 325;
-			left = Math.floor(win.left + (win.width / 2) - (width / 2));
-			top = Math.floor(win.top + (win.height / 2) - (height / 2));
-			
-			return browser.windows.create(
-				{
-					url: browser.extension.getURL("itemSelector/itemSelector.html")
-						+ "#" + encodeURIComponent(JSON.stringify([tab.id, items]))
-						// Remove once https://bugzilla.mozilla.org/show_bug.cgi?id=719905 is fixed
-						.replace(/%3A/g, 'ZOTEROCOLON'),
-					height: height,
-					width: width,
-					top: top,
-					left: left,
-					type: 'popup'
-				})
-		}).then(async function (win) {
-			// Fix positioning in Chrome when window is on second monitor
-			// https://bugs.chromium.org/p/chromium/issues/detail?id=137681
-			if (Zotero.isBrowserExt && win.left < left) {
-				browser.windows.update(win.id, {left});
-			}
-			// Fix a Firefox bug where content does not appear before resize on linux
-			// https://bugzilla.mozilla.org/show_bug.cgi?id=1402110
-			// this one might actually get fixed, unlike the one above
-			if (Zotero.isFirefox) {
-				await Zotero.Promise.delay(1000);
-				browser.windows.update(win.id, {width: win.width+1});
-			}
-			return new Promise(function(resolve) {
-				_tabInfo[tab.id].selectCallback = resolve;
-			});
+	this.onSelect = async function(items, tab) {
+		await Zotero.Connector_Browser.openWindow(
+			browser.extension.getURL("itemSelector/itemSelector.html")
+				+ "#" + encodeURIComponent(JSON.stringify([tab.id, items]))
+				// Remove once https://bugzilla.mozilla.org/show_bug.cgi?id=719905 is fixed
+				.replace(/%3A/g, 'ZOTEROCOLON'),
+			{width: 600, height: 325}, tab
+		);
+		return new Promise(function(resolve) {
+			_tabInfo[tab.id].selectCallback = resolve;
 		});
-	}
+	};
 	
 	/**
 	 * Called when a tab is removed or the URL has changed
@@ -333,6 +307,53 @@ Zotero.Connector_Browser = new function() {
 			clearTimeout(timeout);
 		}
 	};
+	
+	this.openWindow = async function(url, options={}, tab=null) {
+		if (!tab) {
+			tab = (await browser.tabs.query({active: true}))[0];
+		}
+		options = Object.assign({
+			width: 800,
+			height: 600,
+			type: "popup"
+		}, options);
+		let win = await browser.windows.get(tab.windowId, null);
+		options.left = Math.floor(win.left + (win.width / 2) - (options.width / 2));
+		options.top = Math.floor(win.top + (win.height / 2) - (options.height / 2));
+			
+		win = await browser.windows.create({
+			url,
+			type: options.type,
+			width: options.width,
+			height: options.height,
+			left: options.left,
+			top: options.top
+		});
+		
+		// Fix positioning in Chrome when window is on second monitor
+		// https://bugs.chromium.org/p/chromium/issues/detail?id=137681
+		if (Zotero.isBrowserExt && win.left < options.left) {
+			browser.windows.update(win.id, { left: options.left });
+		}
+		// Fix a Firefox bug where content does not appear before resize on linux
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=1402110
+		// this one might actually get fixed, unlike the one above
+		if (Zotero.isFirefox) {
+			await Zotero.Promise.delay(1000);
+			browser.windows.update(win.id, {width: win.width+1});
+		}
+		if (typeof options.onClose == 'function') {
+			browser.windows.onRemoved.addListener(function onClose(id) {
+				if (id == win.id) options.onClose();
+				browser.windows.onRemoved.removeListener(onClose);
+			});
+		}
+	};
+	
+	this.bringToFront = async function(drawAttention=false) {
+		let win = await browser.windows.getLastFocused();
+		browser.windows.update(win.id, {drawAttention, focused: true});
+	}
 
 	this.openTab = function(url, tab) {
 		if (tab) {

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -20,11 +20,14 @@
 			"background.js"
 		]
 	},
-	"content_scripts": [
-		{
+	"content_scripts": [{
 			"matches": ["http://*/*", "https://*/*"],
 			"run_at": "document_start",
 			"js": [/*INJECT SCRIPTS*/]
+		},{
+			"matches": ["https://docs.google.com/*"],
+			"run_at": "document_start",
+			"js": ["zotero-google-docs-integration/kixAddZoteroMenu.js", "zotero-google-docs-integration/client.js"]
 		}
 	],
 	"web_accessible_resources": [

--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -164,6 +164,7 @@ Zotero.Connector = new function() {
 	 *         method - method name
 	 *         headers - an object of HTTP headers to send
 	 *         queryString - a query string to pass on the HTTP call
+	 *         [timeout=15000] - the timeout for the HTTP request
 	 * @param {Object} data - RPC data to POST. If null or undefined, a GET request is sent.
 	 * @param {Function} callback - Function to be called when requests complete.
 	 */
@@ -181,6 +182,7 @@ Zotero.Connector = new function() {
 				"X-Zotero-Version":Zotero.version,
 				"X-Zotero-Connector-API-Version":CONNECTOR_API_VERSION
 			}, options.headers || {});
+		var timeout = "timeout" in options ? options.timeout : 15000;
 		var queryString = options.queryString ? ("?" + options.queryString) : "";
 		
 		var deferred = Zotero.Promise.defer();
@@ -240,7 +242,7 @@ Zotero.Connector = new function() {
 			if (headers["Content-Type"] == 'application/json') {
 				data = JSON.stringify(data);
 			}
-			let options = {body: data, headers, successCodes: false};
+			let options = {body: data, headers, successCodes: false, timeout};
 			let httpMethod = data == null || data == undefined ? "GET" : "POST";
 			Zotero.HTTP.request(httpMethod, uri, options)
 			.then(newCallback)

--- a/src/common/integration/connectorIntegration.js
+++ b/src/common/integration/connectorIntegration.js
@@ -1,0 +1,102 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2017 Center for History and New Media
+					George Mason University, Fairfax, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+/**
+ * An integration interface intended to work via the Zotero client.
+ * See server_connectorIntegration.js in zotero codebase for expected behaviour
+ */
+Zotero.ConnectorIntegration = {
+	init: function() {
+		// Limit to google docs for now
+		if (document.location.host != 'docs.google.com') return;
+		window.addEventListener('Zotero.Integration.execCommand', async function(event) {
+			var client = event.data.client;
+			client.call = function() {
+				var evtName = `${client.name}.call`;
+				window.dispatchEvent(new MessageEvent(evtName, {data: {client, args: Array.from(arguments)}}));
+			};
+			try {
+				await Zotero.ConnectorIntegration.execCommand(client, event.data.command);
+			} catch (e) {
+				Zotero.debug(`Exception in ${e.data.command}`);
+				Zotero.logError(e);
+				var result = {
+					error: e.type || `Connector Error`,
+					message: e.message,
+					stack: e.stack
+				};
+				return Zotero.ConnectorIntegration.respond(client, JSON.stringify(result));
+			}
+		});
+		window.addEventListener('Zotero.Integration.respond', function(event) {
+			var client = event.data.client;
+			client.call = function() {
+				var evtName = `${client.name}.call`;
+				window.dispatchEvent(new MessageEvent(evtName, {data: {client, args: Array.from(arguments)}}));
+			};
+			Zotero.ConnectorIntegration.respond(client, event.data.response);
+		});
+	},
+	
+	execCommand: async function(client, command) {
+		try {
+			var request = await Zotero.Connector.callMethod(
+			{method: 'document/execCommand', timeout: false},
+			{command, docId: client.documentID});
+		} catch (e) {
+			// Usual response for a request in progress
+			if (e.status == 503) {
+				Zotero.debug(e.message);
+				return;
+			} else if (e.status == 0) {
+				Zotero.Inject.confirm({
+					title: "Is Zotero Running?",
+						message: `
+							The Zotero Connector was unable to communicate with the Zotero desktop application. Zotero must be open to cite with ${client.name}.
+							You can <a href="https://www.zotero.org/download/">download Zotero</a> or <a href="https://www.zotero.org/support/kb/connector_zotero_unavailable">troubleshoot the connection</a> if necessary.
+						`,
+					button2Text: "", 
+				});
+			}
+			Zotero.logError(e);
+			return;
+		}
+		return client.call(request);
+	},
+	
+	respond: async function(client, response) {
+		try {
+			var request = await Zotero.Connector.callMethod({method: 'document/respond', timeout: false}, response);
+			return client.call(request);
+		} catch (e) {
+			// Usual response for a request in progress
+			if (e.status == 503) {
+				return;
+			}
+			Zotero.logError(e);
+		}
+	}
+};
+

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -131,7 +131,8 @@ var MESSAGES = {
 		firstSaveToServerPrompt: true,
 		openTab: false,
 		openConfigEditor: false,
-		openPreferences: false
+		openPreferences: false,
+		bringToFront: false
 	},
 	Connector_Debug: {
 		storing: true,
@@ -151,7 +152,12 @@ var MESSAGES = {
 		authorize: true,
 		onAuthorizationComplete: false,
 		clearCredentials: false,
-		getUserInfo: true
+		getUserInfo: true,
+		run: true
+	},
+	GoogleDocs_API: {
+		onAuthComplete: false,
+		run: true
 	},
 	Prefs: {
 		set: false,

--- a/src/common/ui/modal-prompt.jsx
+++ b/src/common/ui/modal-prompt.jsx
@@ -24,12 +24,12 @@
 */
 
 window.Zotero = window.Zotero || {};
-Zotero.ui = Zotero.ui || {};
+Zotero.UI = Zotero.UI || {};
 
 /**
  * Displays a prompt which is overlaid over the screen.
  */
-Zotero.ui.ModalPrompt = React.createClass({
+Zotero.UI.ModalPrompt = React.createClass({
 	propTypes: {
 		title: React.PropTypes.string,
 		/**
@@ -119,6 +119,18 @@ Zotero.ui.ModalPrompt = React.createClass({
 		document.removeEventListener('keyup', this.escListener);
 	},
 	
+	// With synthetic React events you cannot stop event propagation
+	attachButtonListeners: function() {
+		window.requestAnimationFrame(function() {
+			for (let a of document.querySelectorAll('.z-popup-buttons input[type=button]')) {
+				a.addEventListener('mousedown', (event) => {
+					event.stopPropagation();
+					this.state.onButton(this.state, event);
+				}, false);
+			}	
+		}.bind(this));
+	},
+	
 	escListener: function(event) {
 		if (event.key == "Escape") {
 			this.props.onClose(this.state);
@@ -178,8 +190,7 @@ Zotero.ui.ModalPrompt = React.createClass({
 		
 		for (let i = 1; i <= 3; i++) {
 			if (this.props[`button${i}Text`].length) {
-				let onClick = (e) => {e.stopPropagation(); this.state.onButton(this.state, e)};
-				buttons[i-1] = <input type="button" name={i} value={this.props[`button${i}Text`]} onClick={onClick}
+				buttons[i-1] = <input type="button" name={i} value={this.props[`button${i}Text`]}
 					disabled={i==1 && this.state.checkboxBlocked}
 					ref={`button${i}`}
 					style={{
@@ -200,6 +211,8 @@ Zotero.ui.ModalPrompt = React.createClass({
 				}}/>
 			}
 		}
+		
+		this.attachButtonListeners();
 		
 		let onClickOutside = e => {
 			e.stopPropagation();

--- a/src/common/ui/notification.js
+++ b/src/common/ui/notification.js
@@ -27,7 +27,7 @@
 var win = Zotero.isBookmarklet ? window.parent : window,
 	doc = Zotero.isBookmarklet ? window.parent.document : window.document;
 win.Zotero = win.Zotero || {};
-Zotero.ui = Zotero.ui || {};
+Zotero.UI = Zotero.UI || {};
 
 /**
  * @param {String} text notification text
@@ -37,7 +37,7 @@ Zotero.ui = Zotero.ui || {};
  * 	- {Boolean} dismiss	- whether the button click dismisses/removes the notification
  * @constructor
  */
-Zotero.ui.Notification = function(text, buttons) {
+Zotero.UI.Notification = function(text, buttons) {
 	this.text = text;
 	if (!buttons) {
 		buttons = [{
@@ -60,7 +60,7 @@ Zotero.ui.Notification = function(text, buttons) {
 
 // TODO: Put styles in a stylesheet that we insert, so we can use pseudo-classes properly, do proper
 // resetting, etc.
-Zotero.ui.Notification.rootStyle = {
+Zotero.UI.Notification.rootStyle = {
 	// Stay on top of other page elements
 	position: "relative",
 	zIndex: 2147483647,
@@ -77,7 +77,7 @@ Zotero.ui.Notification.rootStyle = {
 	transition: "margin-top 300ms, opacity 300ms"
 };
 
-Zotero.ui.Notification.textStyle = {
+Zotero.UI.Notification.textStyle = {
 	fontFamily: "Lucida Grande, Tahoma, sans",
 	fontSize: "8.5pt",
 	lineHeight: "1.4em",
@@ -85,24 +85,24 @@ Zotero.ui.Notification.textStyle = {
 	color: "rgba(0,0,0,0.95)"
 };
 
-Zotero.ui.Notification.buttonStyle = Object.assign({
+Zotero.UI.Notification.buttonStyle = Object.assign({
 	padding: "3px",
 	textDecoration: "none",
 	margin: "0",
 	marginLeft: "30px",
 	whiteSpace: "nowrap"
-}, Zotero.ui.Notification.textStyle);
+}, Zotero.UI.Notification.textStyle);
 
-Zotero.ui.Notification.prototype = {
+Zotero.UI.Notification.prototype = {
 	show: function() {
 		if (this.deferred) return deferred.promise;
 		this.deferred = Zotero.Promise.defer();
 		var elem = doc.createElement('div');
-		for (let param in Zotero.ui.Notification.rootStyle) {
-			elem.style[param] = Zotero.ui.Notification.rootStyle[param];
+		for (let param in Zotero.UI.Notification.rootStyle) {
+			elem.style[param] = Zotero.UI.Notification.rootStyle[param];
 		}
-		for (let param in Zotero.ui.Notification.textStyle) {
-			elem.style[param] = Zotero.ui.Notification.textStyle[param];
+		for (let param in Zotero.UI.Notification.textStyle) {
+			elem.style[param] = Zotero.UI.Notification.textStyle[param];
 		}
 		let margins = ['marginTop', 'marginRight', 'marginLeft'];
 		let bodyStyle = getComputedStyle(doc.body);
@@ -128,11 +128,11 @@ Zotero.ui.Notification.prototype = {
 			elem = doc.createElement('a');
 			elem.dataset.id = i;
 			elem.setAttribute('href', 'javascript:void(0)');
-			for (let param in Zotero.ui.Notification.buttonStyle) {
-				elem.style[param] = Zotero.ui.Notification.buttonStyle[param];
+			for (let param in Zotero.UI.Notification.buttonStyle) {
+				elem.style[param] = Zotero.UI.Notification.buttonStyle[param];
 			}
-			for (let param in Zotero.ui.Notification.textStyle) {
-				elem.style[param] = Zotero.ui.Notification.textStyle[param];
+			for (let param in Zotero.UI.Notification.textStyle) {
+				elem.style[param] = Zotero.UI.Notification.textStyle[param];
 			}
 			this.elems.buttons.push(elem);
 			this.elems.root.appendChild(elem);

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -48,21 +48,25 @@ var Zotero = new function() {
 	this.isChrome = window.navigator.userAgent.indexOf("Chrome") !== -1 || window.navigator.userAgent.indexOf("Chromium") !== -1;
 	this.isBrowserExt = this.isFirefox || this.isEdge || this.isChrome;
 
+	this.isMac = (window.navigator.platform.substr(0, 3) == "Mac");
+	this.isWin = (window.navigator.platform.substr(0, 3) == "Win");
+	this.isLinux = (window.navigator.platform.substr(0, 5) == "Linux");
+
 	if (this.isFirefox) {
 		this.browser = "g";
-		this.clientName = 'Firefox Connector';
+		this.clientName = 'Zotero Connector for Firefox';
 	} else if (this.isSafari) {
 		this.browser = "s";
-		this.clientName = 'Safari Connector';
+		this.clientName = 'Zotero Connector for Safari';
 	} else if (this.isIE) {
 		this.browser = "i";
-		this.clientName = 'Internet Explorer';
+		this.clientName = 'Zotero Connector for Internet Explorer'; // ?
 	} else if (this.isEdge) {
 		this.browser = "c";
-		this.clientName = 'Edge Connector';
+		this.clientName = 'Zotero Connector for Edge';
 	} else if (this.isChrome) {
 		this.browser = "c";
-		this.clientName = 'Chrome Connector';
+		this.clientName = 'Zotero Connector for Chrome';
 	} else {
 		// Assume this is something with no more capabilities than IE
 		this.browser = "i";
@@ -190,6 +194,10 @@ var Zotero = new function() {
 		Zotero.isInject = true;
 		Zotero.Messaging.init();
 		Zotero.Connector_Types.init();
+		Zotero.ConnectorIntegration.init();
+		if (Zotero.GoogleDocs) {
+			Zotero.GoogleDocs.init();
+		}
 		Zotero.Prefs.loadNamespace(['translators.', 'downloadAssociatedFiles', 'automaticSnapshots',
 			'reportTranslationFailure', 'capitalizeTitles']);
 		return Zotero.Prefs.loadNamespace('debug').then(function() {

--- a/src/common/zotero_config.js
+++ b/src/common/zotero_config.js
@@ -33,11 +33,22 @@ const ZOTERO_CONFIG = {
 	CLIENT_DOWNLOAD_URL: 'https://www.zotero.org/download',
 	API_URL: 'https://api.zotero.org/',
 	CONNECTOR_SERVER_URL: "http://127.0.0.1:23119/",
-	OAUTH_REQUEST_URL: 'https://www.zotero.org/oauth/request',
-	OAUTH_ACCESS_URL: 'https://www.zotero.org/oauth/access',
-	OAUTH_AUTHORIZE_URL: 'https://www.zotero.org/oauth/authorize',
-	OAUTH_CALLBACK_URL: 'https://www.zotero.org/connector_auth_complete',
-	OAUTH_NEW_KEY_URL: 'https://www.zotero.org/settings/keys/new?oauth=1&oauth_consumer_key=05a4e25d3d9af8922eb9',
-	OAUTH_CLIENT_KEY: '05a4e25d3d9af8922eb9',
-	OAUTH_CLIENT_SECRET: '8dda1d6aa188bdd3126e'
+	GOOGLE_DOCS_API_URL: "https://script.googleapis.com/v1/scripts/MLcaOTd_PUYyG7cBwJxdOKvYlDj38wupO:run",
+	OAUTH: {
+		ZOTERO: {
+			REQUEST_URL: 'https://www.zotero.org/oauth/request',
+			ACCESS_URL: 'https://www.zotero.org/oauth/access',
+			AUTHORIZE_URL: 'https://www.zotero.org/oauth/authorize',
+			CALLBACK_URL: 'https://www.zotero.org/connector_auth_complete',
+			CLIENT_KEY: '05a4e25d3d9af8922eb9',
+			CLIENT_SECRET: '8dda1d6aa188bdd3126e'
+		},
+		GOOGLE_DOCS: {
+			AUTHORIZE_URL: 'https://accounts.google.com/o/oauth2/v2/auth',
+			ACCESS_URL: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
+			CALLBACK_URL: 'https://www.zotero.org/connector_auth_complete',
+			CLIENT_KEY: '1064133182604-ofam14dnsunt1h5goa6v0mkr1guqf72a.apps.googleusercontent.com',
+		}
+	},
+	GOOGLE_DOCS_DEV_MODE: false
 };

--- a/src/safari/global.js
+++ b/src/safari/global.js
@@ -91,8 +91,7 @@ Zotero.Connector_Browser = new function() {
 	 */
 	this.onSelect = function(items, tab) {
 		var deferred = Zotero.Promise.defer();
-		var newTab = safari.application.openBrowserWindow().activeTab;
-		newTab.url = safari.extension.baseURI+"itemSelector/itemSelector.html#"+encodeURIComponent(JSON.stringify([tab.id, items]));
+		Zotero.Connector_Browser.openWindow(safari.extension.baseURI+"itemSelector/itemSelector.html#"+encodeURIComponent(JSON.stringify([tab.id, items])));
 		_selectCallbacksForTabIDs[tab.id] = deferred.resolve;
 		return deferred.promise;
 	}
@@ -174,6 +173,18 @@ Zotero.Connector_Browser = new function() {
 		let title = tab.title.split('/');
 		title = title[title.length-1];
 		return Zotero.Messaging.sendMessage("saveAsWebpage", [tab.instanceID || 0, [title, withSnapshot]], tab);
+	}
+
+	this.openWindow = function(url, options={}) {
+		var newTab = safari.application.openBrowserWindow().activeTab;
+		newTab.url = url;
+		if (typeof options.onClose == 'function') {
+			newTab.addEventListener('close', options.onClose);
+		}
+	};
+	
+	this.bringToFront = function() {
+		safari.application.activeBrowserWindow.activate();
 	}
 
 	this.openTab = function(url) {


### PR DESCRIPTION
Adds the submodule for google docs integration.

`integration/connectorIntegration.js` enables anyone to write their own
Zotero integration plugins for web-based editors by exposing the
Integration API to the webpage.  Some security considerations are in order.

TODO: 
- Safari support.
- Move the Google Apps Script API back-end to the Zotero account (currently hosted on mine)
- Testing with multiple doc contributors
- Connector preference to disable the plugin (and disable by default and mark as experimental)
- Make https://www.zotero.org/google-docs lead somewhere
