### PR TITLE
Track master branch of zotero submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/zotero"]
 	path = src/zotero
 	url = git://github.com/zotero/zotero.git
+	branch = master


### PR DESCRIPTION
References the master branch of the zotero submodule so that it can easily be updated using `git submodule update --remote` as e.g. described in https://stackoverflow.com/a/18797720/873661.