### PR TITLE
Use the browserExt API to provide the shortcut for GDocs citing

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -424,6 +424,11 @@ Zotero.Connector_Browser = new function() {
 		return this.notify(text, buttons, seenTimeout, tab);
 	};
 
+	this.getShortcuts = function() {
+		Zotero.debug('getting shortcuts');
+		return browser.commands.getAll();
+	};
+
 	/**
 	 * Update status and tooltip of Zotero button
 	 */
@@ -851,6 +856,10 @@ Zotero.Connector_Browser = new function() {
 		await Zotero.Promise.delay(1);
 		await Zotero.Connector_Browser.onFrameLoaded(tab, details.frameId, details.url);
 	}));
+	
+	browser.commands.onCommand.addListener(function(command) {
+		Zotero.Messaging.sendMessage('command', command);
+	});
 }
 
 Zotero.initGlobal();

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -54,6 +54,13 @@
 			"suggested_key": {
 				"default": "Ctrl+Shift+S"
 			}
+		},
+		"cite": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+C",
+				"mac": "Command+Ctrl+C"
+			},
+			"description": "Add/Edit Citation on Google Docs"
 		}
 	},
 	"minimum_chrome_version": "55",

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -132,6 +132,7 @@ var MESSAGES = {
 		openTab: false,
 		openConfigEditor: false,
 		openPreferences: false,
+		getShortcuts: true,
 		bringToFront: true
 	},
 	Connector_Debug: {


### PR DESCRIPTION
See https://github.com/zotero/zotero-google-docs-integration/issues/24

The benefit of using the browserExt API is that the browser hopefully will not allow invalid shortcuts. The drawbacks is that you cannot use both Ctrl and Alt in a shortcut (which is what our default one does), and if you override a default shortcut (e.g. Ctrl+Shift+C, which is also a shortcut for "Select an element on the page to inspect") then it will not work on any page, not just Google Docs.

Our other option to implement this would be to use our own custom prefs, but that would make it harder to find and more error prone, since we'd have to expose a JSON object to configure it.

Also for some reason the default shortcut (Ctrl+Shift+C) did not automatically get assigned for me on Chrome, perhaps because it overrides a Chrome shortcut, but in that case it falls back to the original shortcut (Ctrl+Alt+C).

![image](https://user-images.githubusercontent.com/5899315/52466160-150a7980-2b8a-11e9-8b0a-78db46714bc7.png)
