### PR TITLE
Use background page for all HTTP requests

### DIFF
--- a/src/common/http.js
+++ b/src/common/http.js
@@ -74,52 +74,35 @@ Zotero.HTTP = new function() {
 			successCodes: null
 		}, options);
 		
-		var useContentXHR = false;
-		
 		if (Zotero.isInject) {
-			// The privileged XHR that Firefox makes available to content scripts so that they
-			// can make cross-domain requests doesn't include the Referer header in requests [1],
-			// so sites that check for it don't work properly. As long as we're not making a
-			// cross-domain request, we can use the content XHR that it provides, which does
-			// include Referer. Chrome's XHR in content scripts includes Referer by default.
-			//
-			// [1] https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts#XHR_and_Fetch
-			if (Zotero.HTTP.isSameOrigin(url)) {
-				if (typeof content != 'undefined' && content.XMLHttpRequest) {
-					Zotero.debug("Using content XHR");
-					useContentXHR = true;
-				}
+			if (Zotero.isBookmarklet) {
+				Zotero.debug("HTTP: Attempting cross-site request from bookmarklet; this may fail");
 			}
+			// Make a cross-origin request via the background page, parsing the responseText with
+			// DOMParser and returning a Proxy with 'response' set to the parsed document
 			else {
-				if (Zotero.isBookmarklet) {
-					Zotero.debug("HTTP: Attempting cross-site request from bookmarklet; this may fail");
+				let isDocRequest = options.responseType == 'document';
+				let coOptions = Object.assign({}, options);
+				if (isDocRequest) {
+					coOptions.responseType = 'text';
 				}
-				else {
-					// Make a cross-origin request via the background page, parsing the responseText with
-					// DOMParser and returning a Proxy with 'response' set to the parsed document
-					let isDocRequest = options.responseType == 'document';
-					let coOptions = Object.assign({}, options);
-					if (isDocRequest) {
-						coOptions.responseType = 'text';
+				return Zotero.COHTTP.request(method, url, coOptions).then(function (xmlhttp) {
+					if (!isDocRequest) return xmlhttp;
+					
+					Zotero.debug("Parsing cross-origin response for " + url);
+					let parser = new DOMParser();
+					let contentType = xmlhttp.getResponseHeader("Content-Type");
+					if (contentType != 'application/xml' && contentType != 'text/xml') {
+						contentType = 'text/html';
 					}
-					return Zotero.COHTTP.request(method, url, coOptions).then(function (xmlhttp) {
-						if (!isDocRequest) return xmlhttp;
-						
-						Zotero.debug("Parsing cross-origin response for " + url);
-						let parser = new DOMParser();
-						let contentType = xmlhttp.getResponseHeader("Content-Type");
-						if (contentType != 'application/xml' && contentType != 'text/xml') {
-							contentType = 'text/html';
+					let doc = parser.parseFromString(xmlhttp.responseText, contentType);
+					
+					return new Proxy(xmlhttp, {
+						get: function (target, name) {
+							return name == 'response' ? doc : target[name];
 						}
-						let doc = parser.parseFromString(xmlhttp.responseText, contentType);
-						
-						return new Proxy(xmlhttp, {
-							get: function (target, name) {
-								return name == 'response' ? doc : target[name];
-							}
-						});
 					});
-				}
+				});
 			}
 		}
 		
@@ -149,7 +132,7 @@ Zotero.HTTP = new function() {
 		}
 		Zotero.debug(`HTTP ${method} ${url}${logBody}`);
 		
-		var xmlhttp = useContentXHR ? new content.XMLHttpRequest() : new XMLHttpRequest();
+		var xmlhttp = new XMLHttpRequest();
 		xmlhttp.timeout = options.timeout;
 		var promise = Zotero.HTTP._attachHandlers(url, xmlhttp, options);
 		


### PR DESCRIPTION
Browsers have been progressively locking down HTTP requests from content
scripts, so we've moved requests to the background page when we know
they're cross-origin. Unfortunately, we can't detect ahead of time if a
request that looks like it will be same-origin redirects to another
domain, causing it to fail due to CORS/CORB [1]. While we could allow
translators to specify when a same-domain request might be redirected
across domains, it's easier to just do all HTTP requests via the
background page. I assume this is slightly less efficient, but it
probably doesn't matter in practice (and we exchange all sorts of
messages with the background page already).

(This addresses an issue reported on the dev list in a now-deleted
message about links such as http://theses.fr/2016ECDN0016/document that
can redirect to a different domain.)

@adomasven, let me know if you can think of any reason not to do this.

[1] https://www.chromium.org/Home/chromium-security/extension-content-script-fetches