### PR TITLE
Removed one comma and two comments from src\browserExt\manifest.json

### DIFF
--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -17,7 +17,7 @@
 	"optional_permissions": ["management"],
 	"background": {
 		"scripts": [
-			/*BACKGROUND SCRIPTS*/,
+			/*BACKGROUND SCRIPTS*/
 			"background.js"
 		]
 	},

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -17,14 +17,13 @@
 	"optional_permissions": ["management"],
 	"background": {
 		"scripts": [
-			/*BACKGROUND SCRIPTS*/
 			"background.js"
 		]
 	},
 	"content_scripts": [{
 			"matches": ["http://*/*", "https://*/*"],
 			"run_at": "document_start",
-			"js": [/*INJECT SCRIPTS*/]
+			"js": []
 		},{
 			"matches": ["https://docs.google.com/document/*"],
 			"run_at": "document_start",


### PR DESCRIPTION
Build process uses jq processing, so comments should either be removed from the json input or filtered out. Additionally, comma on a line containing only a comment should be removed. 