### PR TITLE
Fix CYGWIN/Gulp path issue in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,10 @@ DONE
 }
 
 GULP=$CWD/node_modules/gulp/bin/gulp.js
+if [ "$IS_CYGWIN" == 1 ]; then
+	# Change Gulp path to relative for CYGWIN environment
+	GULP=./node_modules/gulp/bin/gulp.js
+fi
 
 BUILD_BROWSER_EXT=0
 BUILD_SAFARI=0

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,8 +173,11 @@ function replaceScriptsHTML(string, match, scripts) {
 function processFile() {
 	return through.obj(async function(file, enc, cb) {
 		console.log(file.path.slice(file.cwd.length));
-		var offset = file.cwd.split('/').length;
-		var parts = file.path.split('/');
+		// Under CYGWIN environment, the paths are converted to Windows style with "\".
+		// Additional ".replace(/\\/g, '/')" step leaves Linux-style paths as is,
+		// while "\" in Windows-style paths are replaced with "/" for further processing.
+		var offset = file.cwd.replace(/\\/g, '/').split('/').length;
+		var parts = file.path.replace(/\\/g, '/').split('/');
 		var basename = parts[parts.length-1];
 		var ext = basename.split('.')[1];
 		for (var i = offset; i < parts.length; i++) {


### PR DESCRIPTION
There is an apparent path related issue with Gulp when called via absolute path under CYGWIN. The issue does not occur if relative path is used.