### PR TITLE
Fixes #289, PDF save failure in new tabs in Chrome

### DIFF
--- a/src/common/inject/inject.jsx
+++ b/src/common/inject/inject.jsx
@@ -591,8 +591,8 @@ try {
 	isHiddenIFrame = !isTopWindow && window.frameElement && window.frameElement.style.display === "none";
 } catch(e) {}
 
-const isWeb = window.location.protocol === "http:" || window.location.protocol === "https:";
-const isTestPage = Zotero.isBrowserExt && window.location.href.startsWith(browser.extension.getURL('test'));
+var isWeb = window.location.protocol === "http:" || window.location.protocol === "https:";
+var isTestPage = Zotero.isBrowserExt && window.location.href.startsWith(browser.extension.getURL('test'));
 // don't try to scrape on hidden frames
 if(!isHiddenIFrame) {
 	var doInject = function () {

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -63,7 +63,7 @@
  *
  * See other messaging scripts for more details.
  */
-const MESSAGE_SEPARATOR = ".";
+var MESSAGE_SEPARATOR = ".";
 var MESSAGES = {
 	Translators: {
 		get: {

--- a/src/common/zotero_config.js
+++ b/src/common/zotero_config.js
@@ -23,7 +23,7 @@
     ***** END LICENSE BLOCK *****
 */
 
-const ZOTERO_CONFIG = {
+var ZOTERO_CONFIG = {
 	CLIENT_NAME: 'Zotero',
 	DOMAIN_NAME: 'zotero.org',
 	REPOSITORY_URL: 'https://repo.zotero.org/repo/',


### PR DESCRIPTION
I don't know why content scripts seem to be getting injected more than
once on PDFs loaded in new tabs in Chrome, but this seems to fix the
breakage that results.