### PR TITLE
Switch back to SingleFile from SingleFileZ

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -287,12 +287,12 @@ function copyResources {
 	# Remove .jsx files - we'll deal with those in gulp
 	find "$browser_builddir" -type f -name "*.jsx" -delete
 
-	# Copy SingleFileZ submodule code
-	mkdir -p "$browser_builddir/lib/SingleFileZ/extension/lib"
-	cp -r "$SRCDIR/zotero/resource/SingleFileZ/extension/lib/single-file" \
-		"$browser_builddir/lib/SingleFileZ/extension/lib/single-file"
-	cp -r "$SRCDIR/zotero/resource/SingleFileZ/lib" "$browser_builddir/lib/SingleFileZ/lib"
-	# Copy SingleFileZ config object from client code
+	# Copy SingleFile submodule code
+	mkdir -p "$browser_builddir/lib/SingleFile/extension/lib"
+	cp -r "$SRCDIR/zotero/resource/SingleFile/extension/lib/single-file" \
+		"$browser_builddir/lib/SingleFile/extension/lib/single-file"
+	cp -r "$SRCDIR/zotero/resource/SingleFile/lib" "$browser_builddir/lib/SingleFile/lib"
+	# Copy SingleFile config object from client code
 	cp "$SRCDIR/zotero/chrome/content/zotero/xpcom/singlefile.js" "$browser_builddir/singlefile-config.js"
 	
 	if [ ! -z $DEBUG ]; then

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,13 +132,13 @@ var backgroundInclude = [
 	'google-docs-plugin-manager.js',
 	'messages.js',
 	'messaging.js',
-	'lib/SingleFileZ/lib/single-file/index.js',
-	'lib/SingleFileZ/extension/lib/single-file/index.js',
-	'lib/SingleFileZ/extension/lib/single-file/browser-polyfill/chrome-browser-polyfill.js',
-	'lib/SingleFileZ/extension/lib/single-file/core/bg/scripts.js',
-	'lib/SingleFileZ/extension/lib/single-file/fetch/bg/fetch.js',
-	'lib/SingleFileZ/extension/lib/single-file/frame-tree/bg/frame-tree.js',
-	'lib/SingleFileZ/extension/lib/single-file/lazy/bg/lazy-timeout.js'
+	'lib/SingleFile/lib/single-file/index.js',
+	'lib/SingleFile/extension/lib/single-file/index.js',
+	'lib/SingleFile/extension/lib/single-file/browser-polyfill/chrome-browser-polyfill.js',
+	'lib/SingleFile/extension/lib/single-file/core/bg/scripts.js',
+	'lib/SingleFile/extension/lib/single-file/fetch/bg/fetch.js',
+	'lib/SingleFile/extension/lib/single-file/frame-tree/bg/frame-tree.js',
+	'lib/SingleFile/extension/lib/single-file/lazy/bg/lazy-timeout.js'
 ];
 
 
@@ -341,11 +341,11 @@ function processFile() {
 
 		// sourcefile is relative to the src/ directory
 		switch (sourcefile) {
-			case 'zotero/resource/SingleFileZ/extension/lib/single-file/core/bg/scripts.js':
+			case 'zotero/resource/SingleFile/extension/lib/single-file/core/bg/scripts.js':
 				// Change base path and add in the content scripts SingleFile recommends injecting
 				// via manifest.json
 				file.contents = Buffer.from(file.contents.toString()
-					.replace('const basePath = "../../../";', 'const basePath = "lib/SingleFileZ/";')
+					.replace('const basePath = "../../../";', 'const basePath = "lib/SingleFile/";')
 				);
 
 				// Override the type so we include this file in firefox and chrome builds
@@ -353,11 +353,11 @@ function processFile() {
 				// Switch from resource to lib sub-directory
 				parts[i+1] = 'lib';
 				break;
-			case 'zotero/resource/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks-frames.js':
+			case 'zotero/resource/SingleFile/lib/single-file/processors/hooks/content/content-hooks-frames.js':
 				// Change the path to include our particular directory structure
 				file.contents = Buffer.from(file.contents.toString()
 					.replace('/lib/single-file/processors/hooks/content/content-hooks-frames-web.js',
-					'/lib/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks-frames-web.js')
+					'/lib/SingleFile/lib/single-file/processors/hooks/content/content-hooks-frames-web.js')
 				);
 
 				// Override the type so we include this file in firefox and chrome builds
@@ -365,25 +365,11 @@ function processFile() {
 				// Switch from resource to lib sub-directory
 				parts[i+1] = 'lib';
 				break;
-			case 'zotero/resource/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks.js':
+			case 'zotero/resource/SingleFile/lib/single-file/processors/hooks/content/content-hooks.js':
 				// Change the path to include our particular directory structure
 				file.contents = Buffer.from(file.contents.toString()
 					.replace('/lib/single-file/processors/hooks/content/content-hooks-web.js',
-						'/lib/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks-web.js')
-				);
-
-				// Override the type so we include this file in firefox and chrome builds
-				type = 'browserExt';
-				// Switch from resource to lib sub-directory
-				parts[i+1] = 'lib';
-				break;
-			case 'zotero/resource/SingleFileZ/lib/single-file/index.js':
-				// Change the object references to work correctly
-				file.contents = Buffer.from(file.contents.toString()
-					.replace('this.frameTree.content.frames.getAsync',
-						'this.processors.frameTree.content.frames.getAsync')
-					.replace('this.lazy.content.loader.process',
-						'this.processors.lazy.content.loader.process')
+						'/lib/SingleFile/lib/single-file/processors/hooks/content/content-hooks-web.js')
 				);
 
 				// Override the type so we include this file in firefox and chrome builds
@@ -483,11 +469,9 @@ gulp.task('process-custom-scripts', function() {
 		'./src/common/test/**/*',
 		'./src/**/*.jsx',
 		'./src/zotero-google-docs-integration/src/connector/**',
-		'./src/zotero/resource/SingleFileZ/extension/lib/single-file/core/bg/scripts.js',
-		'./src/zotero/resource/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks.js',
-		'./src/zotero/resource/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks-frames.js',
-		'./src/zotero/resource/SingleFileZ/lib/single-file/index.js',
-		'./src/zotero/resource/SingleFileZ/extension/lib/single-file/index.js'
+		'./src/zotero/resource/SingleFile/extension/lib/single-file/core/bg/scripts.js',
+		'./src/zotero/resource/SingleFile/lib/single-file/processors/hooks/content/content-hooks.js',
+		'./src/zotero/resource/SingleFile/lib/single-file/processors/hooks/content/content-hooks-frames.js'
 	];
 	if (!argv.p) {
 		sources.push('./src/common/test/**/*.js');	

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -32,8 +32,8 @@
 		"progressWindow/progressWindow.html",
 		"modalPrompt/modalPrompt.html",
 		"test/data/journalArticle-single.html",
-		"lib/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks-web.js",
-		"lib/SingleFileZ/lib/single-file/processors/hooks/content/content-hooks-frames-web.js"
+		"lib/SingleFile/lib/single-file/processors/hooks/content/content-hooks-web.js",
+		"lib/SingleFile/lib/single-file/processors/hooks/content/content-hooks-frames-web.js"
 	],
 	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
 	"homepage_url": "https://www.zotero.org/",


### PR DESCRIPTION
We cannot use the directory structure from SingleFileZ due to limitations
on Zotero syncing for sub-directories of attachments so we are switching.

Note: this does not have any fix for the message size issue but the page posted in #333 no longer throws an error because of the switch to base64 so I'm thinking we should get this out and then I'll fix that issue.