### PR TITLE
`Zotero.HTTP.request()`: Support 'json' responseType, return URL for `wrapDocument()`

### DIFF
--- a/src/common/http.js
+++ b/src/common/http.js
@@ -204,6 +204,7 @@ Zotero.HTTP = new function() {
 		return {
 			responseText: typeof responseData == 'string' ? responseData : '',
 			response: responseData,
+			responseURL: response.url,
 			status: response.status,
 			statusText: response.statusText,
 			getAllResponseHeaders: () => responseHeadersString,

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -170,7 +170,10 @@ Zotero.HTTP = new function() {
 		let responseData;
 		if (options.responseType == 'arraybuffer') {
 			responseData = await response.arrayBuffer();
-		} 
+		}
+		else if (options.responseType == 'json') {
+			responseData = await response.json();
+		}
 		else {
 			responseData = await response.text();
 		} 


### PR DESCRIPTION
So apparently `request()` in the Connector didn't support returning JSON, which has been breaking our very few translators that call `requestJSON()`. Go figure! I probably should've caught that before merging in the async request functions. We also weren't returning `responseURL`, which `requestDocument()` uses to construct a wrapped Document.

(Some of these may be MV3 regressions, not sure, but I'm seeing them in the latest stable version on Firefox.)