### PR TITLE
Fix advanced-checkbox-enable-at-startup

### DIFF
--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -274,6 +274,8 @@ Zotero_Preferences.Advanced = {
 			document.getElementById('advanced-checkbox-enable-logging').checked = !!status;
 		});
 		Zotero.Prefs.getAsync("debug.store").then(function(status) {
+			document.getElementById("advanced-checkbox-enable-logging").checked = !!status;
+			document.getElementById("advanced-checkbox-enable-logging").onchange();
 			document.getElementById('advanced-checkbox-enable-at-startup').checked = !!status;
 		});
 		Zotero.Prefs.getAsync("debug.log").then(function(status) {


### PR DESCRIPTION
Surprisingly, this option never takes effect.
I did not create a forum post to ask, and I was not sure if it was necessary. Hope this is not a mistake.