### PR TITLE
Proxies: add more sophisticated proxy redirection loop prevention

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -680,6 +680,9 @@ Zotero.Connector_Browser = new function() {
 			const proxyIdx = parts[parts.length-1];
 			const proxy = Zotero.Proxies.proxies[proxyIdx];
 			const proxied = proxy.toProxy(tab.url);
+			if (Zotero.Proxies.isPreventingRedirectLoops()) {
+				Zotero.Proxies.toggleRedirectLoopPrevention(false)
+			}
 			browser.tabs.update({ url: proxied });
 		}
 	}

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -220,7 +220,8 @@ var MESSAGES = {
 	Proxies: {
 		loadPrefs: false,
 		save: false,
-		remove: false
+		remove: false,
+		toggleRedirectLoopPrevention: false
 	},
 	Repo: {
 		update: false

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -482,7 +482,7 @@ Zotero_Preferences.Components.ProxyPreferences = class ProxyPreferences extends 
 		if (this.state.loopPreventionTimestamp > Date.now() && this.state.transparent) {
 			redirectLoopPrevention = (
 				<div className="group">
-					<b>Zotero detected a proxy redirect loop and has temporarily suspended automatic proxy redirection</b> <input type="button" onClick={this.reenableProxyRedirection} value="Reenable proxy redirection"/>
+					<b>Zotero detected a proxy redirect loop and has temporarily suspended automatic proxy redirection.</b> <input type="button" onClick={this.reenableProxyRedirection} value="Reenable proxy redirection"/>
 				</div>
 			)
 		}

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -415,6 +415,7 @@ Zotero.Prefs = new function() {
 		"proxies.disableByDomainString": '.edu',
 		"proxies.proxies": [],
 		"proxies.clientChecked": false,
+		"proxies.loopPreventionTimestamp": 0,
 		
 		"integration.googleDocs.enabled": true,
 		"integration.googleDocs.useGoogleDocsAPI": false,


### PR DESCRIPTION
Regression from 13c45cb6
Reports in https://forums.zotero.org/discussion/102507/zotero-causing-continuous-article-download-request-loop

Changes in 13c45cb6 made us redirect to ezproxy resources via the /login?url= links which is the appropriate way to redirect via proxy instead of manually rewriting urls to their final form however this type of redirection causes multiple requests and so the unsophisticated single-request proxy loop prevention code was no longer sufficient.

This commit adds a more sophisticated system that watches tabs after redirection to ensure they don't end up navigating back to the original URL for a set number of navigation events. If the tab ends up looping we add a temporary block to proxy redirection and show a message in preferences with a button to reenable automatic redirection.

![image](https://user-images.githubusercontent.com/5899315/216323633-01a25423-cc96-427f-8f69-0ae5c4c81aa5.png)

I'm slightly worried this will cause false postives. Monitoring is per-tab so following a bunch of unproxied links in new tabs won't cause the block, but copying and pasting unproxied links to the same tab multiple times will. I'm not sure this is a very common workflow at all.

You may force the proxy redirection blocking by navigating to some website that has automatic proxy redirection, causing Zotero to redirect, then navigating back to that same domain manually (by typing/pasting URL). Pressing back won't force the block since that would cause accidental false-positives.