### PR TITLE
Testing: Fix failure to run non-web translators' tests in debug build.

### DIFF
--- a/src/common/cachedTypes.js
+++ b/src/common/cachedTypes.js
@@ -178,7 +178,7 @@ Zotero.Connector_Types = new function() {
 	/**
 	 * Passes schema to a callback
 	 */
-	this.getSchema = async function() {
-		return TypeSchema;
+	this.getSchema = async function(callback) {
+		return callback(TypeSchema);
 	};
 }

--- a/src/common/tools/testTranslators/testTranslators.html
+++ b/src/common/tools/testTranslators/testTranslators.html
@@ -31,7 +31,7 @@
 		<script type="text/javascript" src="/zotero_config.js"></script>
 		<script type="text/javascript" src="/zotero.js"></script>
 		<script type="text/javascript" src="/translate/promise.js"></script>
-		<script type="text/javascript" src="/translate/resource/zoteroTypeSchemaData.js"></script>
+		<script type="text/javascript" src="/utilities/resource/zoteroTypeSchemaData.js"></script>
 		<script type="text/javascript" src="/utilities/schema.js"></script>
 		<script type="text/javascript" src="/cachedTypes.js"></script>
 		<script type="text/javascript" src="/schema.js"></script>


### PR DESCRIPTION
- In the testTranslators tool included in the debug build, there is an incorrect script path preventing the type schema data from loading.
- In cachedTypes.js, the callback passed to `getSchema()` is not called. (The call site is in `translatorTester_viewer.js`).

The overall effect is that non-web translators' test code did not run at all.

This is fixed by including the correct script path, and call the callback in `getSchema()`.