### PR TITLE
Add Chrome Web Store public key to manifest.json

### DIFF
--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -78,5 +78,6 @@
 			"update_url": "https://zotero.org/AUTOFILLED",
 			"strict_min_version": "51.0"
 		}
-	}
+	},
+	"key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDllBS5q+Z9T9tPgYwRN+/8T9wzyjo9tRo03Wy8zP2DQ5Iy+3q0Tjq2vKXGiMCxC/ZVuEMC68Ekv+jNT43VxPbEXI4dzpK1GMBqPJpAcEOB8B1ROBouQMbGGTG7fOdQVlmpdTTPVndVwysJ02CrDMn96IG2ytOq2PO7GR2xleCudQIDAQAB"
 }


### PR DESCRIPTION
See https://developer.chrome.com/docs/extensions/reference/manifest/key#keep-consistent-id

With the key added to `manifest.json`, the extension's ID will be the same when loaded unpacked for debugging as it is when downloaded from the Chrome Web Store. That eliminates the need for all the [weirdness](https://github.com/zotero/translators/pull/3210) that we need to do to find the extension ID when we test translators using Selenium (which is the most commonly broken part of our translator tester).

(`key` is what you get when you run `chrome.runtime.getManifest().key` from the extension when it's installed from the Chrome Web Store. Here we hardcode it for non-Chrome Web Store installs.)