### PR TITLE
vpat 39: add aria labels to expand/collapse target button

### DIFF
--- a/src/common/ui/ProgressWindow.jsx
+++ b/src/common/ui/ProgressWindow.jsx
@@ -62,7 +62,9 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 			more: Zotero.getString('general_more'),
 			done: Zotero.getString('general_done'),
 			tagsPlaceholder: Zotero.getString('progressWindow_tagPlaceholder'),
-			filterPlaceholder: Zotero.getString('progressWindow_filterPlaceholder')
+			filterPlaceholder: Zotero.getString('progressWindow_filterPlaceholder'),
+			collapseBtn: Zotero.getString('progressWindow_collapse'),
+			expandBtn: Zotero.getString('progressWindow_expand'),
 		};
 		
 		this.expandedRowsCache = {};
@@ -548,6 +550,8 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 				</select>
 				<button className={"ProgressWindow-disclosure"
 							+ (this.state.targetSelectorShown ? " is-open" : "")}
+						aria-expanded={this.state.targetSelectorShown}
+						aria-label={this.state.targetSelectorShown ? this.text.collapseBtn : this.text.expandBtn }
 						onClick={this.onDisclosureChange}
 						onKeyPress={this.handleDisclosureKeyPress}/>
 			</React.Fragment>

--- a/src/messages.json
+++ b/src/messages.json
@@ -48,6 +48,12 @@
 	"progressWindow_savingTo": {
 		"message": "Saving to"
 	},
+	"progressWindow_expand": {
+		"message": "Expand collection selector"
+	},
+	"progressWindow_collapse": {
+		"message": "Collapse collection selector"
+	},
 	"progressWindow_tagPlaceholder": {
 		"message": "Tags (separated by commas)"
 	},


### PR DESCRIPTION
Add aria-expanded status and aria-label to the button that displays collection selector.

---

VPAT 39 description:

In the Zotero desktop app's browser addon, there is a button to expand or collapse the menu to provide additional information to the user. When using a screen reader, this button element does not have an accessible name. It also lacks a state to indicate whether the menu is expanded or collapsed. 

Impact Statement: When operable elements lack appropriate roles and states, users relying on assistive technologies (AT) may miss out on important functionality. If a collapsed menu is not announced as a collapsed menu, users may not realize it is operable and can be activated to show its expanded form. These issues are particularly impactful for users with visual or cognitive disabilities. 

Expected Result: Operable elements have appropriate names, roles, and states conveyed to users by assistive technologies. 

Actual Result: The expand/collapse menu button does not have a role or state conveyed to users by assistive technologies.