### PR TITLE
vpat: no focus shift if expanded via keypress

### DIFF
--- a/src/common/ui/ProgressWindow.jsx
+++ b/src/common/ui/ProgressWindow.jsx
@@ -353,9 +353,11 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		this.onTargetChange(event.target.value);
 	}
 	
-	onDisclosureChange() {
+	onDisclosureChange(e) {
+		let viaKeyPress = e.nativeEvent.clientY == 0 && e.nativeEvent.clientX == 0;
 		var show = !this.state.targetSelectorShown;
-		if (show) {
+		// No refocus on click triggered from keyboard
+		if (show && !viaKeyPress) {
 			this.focusTreeOnUpdate = true;
 		}
 		this.setState({


### PR DESCRIPTION
Do not shift focus onto the collection row if the target selector was opened via keypress and not via mouse click. This was not explicitly reported during VPAT review but vpat 44 (addressed in https://github.com/zotero/zotero/pull/4069) raises a similar issue where focus should not move on button click per https://www.w3.org/WAI/WCAG21/Understanding/on-input


With voiceover enabled, if you focus the button and press space to click it, focus will jump to the collection tree, which is not quite expected and can be disorientating. Just like in that PR, I think a decent compromise is to keep focus on the twisty if keypress happened via keyboard but let focus jump to collection row after mouse click. 

We could wait for the fix from https://github.com/zotero/zotero/pull/4069 to be merged and approved by the VPAT reviewers before doing this.