### PR TITLE
add dialog role to save item popup

### DIFF
--- a/src/common/progressWindow/progressWindow.html
+++ b/src/common/progressWindow/progressWindow.html
@@ -30,6 +30,6 @@
 		<link rel="stylesheet" href="progressWindow.css" />
 	</head>
 	<body>
-		<div id="progress-window"></div>
+		<div id="progress-window" role="dialog"></div>
 	</body>
 </html>

--- a/src/common/ui/ProgressWindow.jsx
+++ b/src/common/ui/ProgressWindow.jsx
@@ -62,7 +62,8 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 			more: Zotero.getString('general_more'),
 			done: Zotero.getString('general_done'),
 			tagsPlaceholder: Zotero.getString('progressWindow_tagPlaceholder'),
-			filterPlaceholder: Zotero.getString('progressWindow_filterPlaceholder')
+			filterPlaceholder: Zotero.getString('progressWindow_filterPlaceholder'),
+			saveToZotero: Zotero.getString('progressWindow_saveToZotero')
 		};
 		
 		this.expandedRowsCache = {};
@@ -118,6 +119,8 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		(new Image()).src = 'disclosure-open.svg';
 		
 		this.sendMessage('registered');
+		
+		document.querySelector("#progress-window").setAttribute("aria-label", this.text.saveToZotero);
 	}
 	
 	

--- a/src/messages.json
+++ b/src/messages.json
@@ -48,6 +48,9 @@
 	"progressWindow_savingTo": {
 		"message": "Saving to"
 	},
+	"progressWindow_saveToZotero": {
+		"message": "Save to Zotero"
+	},
 	"progressWindow_tagPlaceholder": {
 		"message": "Tags (separated by commas)"
 	},


### PR DESCRIPTION
With the "Save to zotero" aria-label, screen readers should announce it when focus enters or leaves the dialog.

Addresses https://github.com/zotero/zotero-connectors/issues/469#issuecomment-2084448366


