### PR TITLE
accessibility localization tweaks

### DIFF
--- a/src/common/inject/inject.jsx
+++ b/src/common/inject/inject.jsx
@@ -264,6 +264,7 @@ Zotero.Inject = new function() {
 		if (attachment.linkMode === "linked_url") return Zotero.getString("itemType_link");
 		var contentType = attachment.contentType || attachment.mimeType;
 		if (contentType == "application/pdf") return Zotero.getString("itemType_pdf");
+		if (contentType == "application/epub+zip") return Zotero.getString("itemType_epub");
 		if (contentType == "text/html") return Zotero.getString("itemType_snapshot");
 		return Zotero.getString("itemType_attachment");
 	}

--- a/src/common/inject/progressWindow_inject.js
+++ b/src/common/inject/progressWindow_inject.js
@@ -230,6 +230,7 @@ if (isTopWindow) {
 		var iframe = document.createElement('iframe');
 		iframe.id = frameID;
 		iframe.src = frameSrc;
+		iframe.title = Zotero.getString('general_saveTo', 'Zotero');
 		iframe.setAttribute('data-single-file-hidden-frame', '');
 		var style = {
 			position: 'fixed',
@@ -477,6 +478,7 @@ if (isTopWindow) {
 		}
 		else if (returnValue[0]) {
 			startCloseTimer(3000);
+			addEvent("willHide");
 		}
 		else {
 			if (returnValue.length < 2) {

--- a/src/messages.json
+++ b/src/messages.json
@@ -97,6 +97,12 @@
 	"progressWindow_downloadFailedPlural": {
 		"message": "Failed download of $1 for item $2"
 	},
+	"progressWindow_allDone": {
+		"message": "Saving is complete. The dialog will close now."
+	},
+	"progressWindow_alreadySaved": {
+		"message": "Items from this webpage have already been processed."
+	},
 	"progressWindow_tagPlaceholder": {
 		"message": "Tags (separated by commas)"
 	},

--- a/src/messages.json
+++ b/src/messages.json
@@ -86,13 +86,13 @@
 		"message": "Item $1: $2"
 	},
 	"progressWindow_downloadComplete": {
-		"message": "Saved $1 for this item"
+		"message": "Saved $1"
 	},
 	"progressWindow_downloadCompletePlural": {
 		"message": "Saved $1 for item $2"
 	},
 	"progressWindow_downloadFailed": {
-		"message": "Failed download of $1 for this item"
+		"message": "Failed download of $1"
 	},
 	"progressWindow_downloadFailedPlural": {
 		"message": "Failed download of $1 for item $2"
@@ -101,7 +101,7 @@
 		"message": "Saving is complete. The dialog will close now."
 	},
 	"progressWindow_alreadySaved": {
-		"message": "Items from this webpage have already been processed."
+		"message": "Items from this webpage have already been saved."
 	},
 	"progressWindow_tagPlaceholder": {
 		"message": "Tags (separated by commas)"

--- a/src/messages.json
+++ b/src/messages.json
@@ -48,6 +48,9 @@
 	"itemType_pdf": {
 		"message": "PDF attachment"
 	},
+	"itemType_epub": {
+		"message": "EPUB attachment"
+	},
 	"itemType_snapshot": {
 		"message": "Snapshot"
 	},
@@ -55,7 +58,7 @@
 		"message": "Note"
 	},
 	"itemType_link": {
-		"message": "Linked attachment"
+		"message": "Web link"
 	},
 	"itemType_attachment": {
 		"message": "Attachment"
@@ -64,22 +67,34 @@
 	"progressWindow_savingTo": {
 		"message": "Saving to"
 	},
-	"progressWindow_saveToZotero": {
-		"message": "Save to Zotero"
+	"progressWindow_detailsBtnView": {
+		"message": "View details"
+	},
+	"progressWindow_detailsBtnHide": {
+		"message": "Hide details"
+	},
+	"progressWindow_collectionSelector": {
+		"message": "Target collection selector"
 	},
 	"progressWindow_savingItems": {
 		"message": "Saving $1 items. $2"
 	},
 	"progressWindow_savingItem": {
-		"message": "Saving 1 item. $2"
+		"message": "Saving item $1"
 	},
 	"progressWindow_saveItem": {
 		"message": "Item $1: $2"
 	},
 	"progressWindow_downloadComplete": {
+		"message": "Saved $1 for this item"
+	},
+	"progressWindow_downloadCompletePlural": {
 		"message": "Saved $1 for item $2"
 	},
 	"progressWindow_downloadFailed": {
+		"message": "Failed download of $1 for this item"
+	},
+	"progressWindow_downloadFailedPlural": {
 		"message": "Failed download of $1 for item $2"
 	},
 	"progressWindow_tagPlaceholder": {


### PR DESCRIPTION
- Removed "Item 1" prefix if only one item is being saved. The new announcements will be just "Saving item {title}. Saved snapshot for this item"
- "Web link" instead of "Linked attachment" as the item type label
- Added epub content type to be announced as an attachment
- Use `general_saveTo` string for the label of the dialog
- Added aria-labels to the expand/collapse twisty button (vpat 39). I started with "View details"/"Hide details". Correct me if there's a more descriptive way than "details" to refer to the collections table and the tags area together.
- Added aria-label to the collection selector table so that it indicates what that element if for when a row is focused. Again, let me know if there is a better way to name this than "Target collection selector".
- Fixed a race condition bug to not trigger handle alerts until all top level items are 100 percent loaded.

Fixes: #472