### PR TITLE
Add support for attachment type priority customization

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -751,8 +751,7 @@ Zotero.Connector_Browser = new function() {
 			tabId: tab.id,
 			path: Zotero.ItemTypes.getImageSrc("webpage-gray")
 		});
-		let withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.automaticSnapshots :
-			Zotero.Prefs.get('automaticSnapshots');
+		let withSnapshot = Zotero.Connector.automaticSnapshots;
 		let title = `Save to Zotero (Web Page ${withSnapshot ? 'with' : 'without'} Snapshot)`;
 		browser.action.setTitle({tabId: tab.id, title});
 	}
@@ -804,8 +803,7 @@ Zotero.Connector_Browser = new function() {
 			contexts: ['page', ...buttonContext]
 		}));
 		// Swap order if automatic snapshots disabled
-		let withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.automaticSnapshots :
-			Zotero.Prefs.get('automaticSnapshots');
+		let withSnapshot = Zotero.Connector.automaticSnapshots;
 		if (!withSnapshot) {
 			fns = [fns[1], fns[0]];
 		}
@@ -957,8 +955,7 @@ Zotero.Connector_Browser = new function() {
 					}
 				);
 			} else {
-				let withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.automaticSnapshots :
-					Zotero.Prefs.get('automaticSnapshots');
+				let withSnapshot = Zotero.Connector.automaticSnapshots;
 				Zotero.Connector_Browser.saveAsWebpage(tab, 0, { snapshot: withSnapshot });
 			}
 		}

--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -62,7 +62,20 @@ Zotero.Connector = new function() {
 		let response = await Zotero.Connector.callMethod("ping", payload);
 		if (response && 'prefs' in response) {
 			Zotero.Connector.shouldReportActiveURL = !!response.prefs.reportActiveURL;
-			Zotero.Connector.automaticSnapshots = !!response.prefs.automaticSnapshots;
+			Zotero.Connector.automaticAttachmentTypes = response.prefs.automaticAttachmentTypes;
+			Zotero.Connector.automaticAttachmentTypesOrder = response.prefs.automaticAttachmentTypesOrder;
+			// Old client returns downloadAssociatedFiles and automaticSnapshots instead
+			if (!Zotero.Connector.automaticAttachmentTypes && !Zotero.Connector.automaticAttachmentTypesOrder) {
+				let types = [];
+				if (response.prefs.downloadAssociatedFiles) {
+					types.push('pdf', 'epub');
+				}
+				if (response.prefs.automaticSnapshots) {
+					types.push('html');
+				}
+				Zotero.Connector.automaticAttachmentTypes = types.join(',');
+				Zotero.Connector.automaticAttachmentTypesOrder = 'pdf,epub,html';
+			}
 			Zotero.Connector.googleDocsAddNoteEnabled = !!response.prefs.googleDocsAddNoteEnabled;
 			Zotero.Connector.googleDocsCitationExplorerEnabled = !!response.prefs.googleDocsCitationExplorerEnabled;
 			if (response.prefs.translatorsHash) {
@@ -82,6 +95,19 @@ Zotero.Connector = new function() {
 		let isOnline = await this.checkIsOnline();
 		return isOnline && this.clientVersion;
 	}
+	
+	Object.defineProperty(this, 'automaticSnapshots', {
+		get() {
+			let pref;
+			if (this.isOnline) {
+				pref = Zotero.Connector.automaticAttachmentTypes;
+			}
+			else {
+				pref = Zotero.Prefs.get('automaticAttachmentTypes');
+			}
+			return pref.split(',').includes('html');
+		}
+	});
 	
 	/**
 	 * Sends the XHR to execute an RPC call.

--- a/src/common/preferences/preferences.html
+++ b/src/common/preferences/preferences.html
@@ -56,8 +56,8 @@
 							<input type="button" value="Clear Credentials" id="general-button-clear-credentials"/>
 						</p>
 						<p>
-							<label><input type="checkbox" data-pref="automaticSnapshots"/>&nbsp;Automatically take snapshots when saving items</label>
-							<label><input type="checkbox" data-pref="downloadAssociatedFiles"/>&nbsp;Automatically download associated PDFs and other files when saving items</label>
+							<label><input type="checkbox" id="general-checkbox-automatic-snapshots"/>&nbsp;Automatically take snapshots when saving items</label>
+							<label><input type="checkbox" id="general-checkbox-download-associated-files"/>&nbsp;Automatically download associated PDFs and other files when saving items</label>
 						</p>
 					</div>
 				</div>

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -172,6 +172,35 @@ Zotero_Preferences.General = {
 
 		Zotero.API.getUserInfo().then(Zotero_Preferences.General.updateAuthorization);
 
+		let automaticAttachmentTypes = new Set(Zotero.Prefs.get('automaticAttachmentTypes').split(','));
+		let checkboxAutomaticSnapshots = document.getElementById('general-checkbox-automatic-snapshots');
+		let checkboxDownloadAssociatedFiles = document.getElementById('general-checkbox-download-associated-files');
+		
+		checkboxAutomaticSnapshots.checked = automaticAttachmentTypes.has('html');
+		checkboxAutomaticSnapshots.onchange = () => {
+			if (checkboxAutomaticSnapshots.checked) {
+				automaticAttachmentTypes.add('html');
+			}
+			else {
+				automaticAttachmentTypes = automaticAttachmentTypes.remove('html');
+			}
+			Zotero.Prefs.set('automaticAttachmentTypes', Array.from(automaticAttachmentTypes).join(','));
+		};
+		
+		checkboxDownloadAssociatedFiles.checked = automaticAttachmentTypes.has('pdf')
+			&& automaticAttachmentTypes.has('epub');
+		checkboxDownloadAssociatedFiles.onchange = () => {
+			if (checkboxDownloadAssociatedFiles.checked) {
+				automaticAttachmentTypes.add('pdf');
+				automaticAttachmentTypes.add('epub');
+			}
+			else {
+				automaticAttachmentTypes = automaticAttachmentTypes.remove('pdf');
+				automaticAttachmentTypes = automaticAttachmentTypes.remove('epub');
+			}
+			Zotero.Prefs.set('automaticAttachmentTypes', Array.from(automaticAttachmentTypes).join(','));
+		};
+
 	},
 
 	/**

--- a/src/common/translate_item.js
+++ b/src/common/translate_item.js
@@ -404,7 +404,7 @@ Zotero.Translate.ItemSaver.prototype = {
 		}
 		
 		Zotero.debug("Translate: Save to server complete");
-		return Zotero.Prefs.getAsync(["downloadAssociatedFiles", "automaticSnapshots"])
+		return Zotero.Prefs.getAsync(["automaticAttachmentTypes", "automaticAttachmentTypes.order"])
 		.then(function (prefs) {
 			if (typedArraysSupported) {
 				for (var i=0; i<items.length; i++) {
@@ -426,7 +426,8 @@ Zotero.Translate.ItemSaver.prototype = {
 	 * @param {String} itemKey The key of the parent item
 	 * @param {String} baseName A string to use as the base name for attachments
 	 * @param {Object[]} attachments An array of attachment objects
-	 * @param {Object} prefs An object with the values of the downloadAssociatedFiles and automaticSnapshots preferences
+	 * @param {Object} prefs An object with the values of the automaticAttachmentTypes and
+	 *     automaticAttachmentTypes.order preferences
 	 * @param {Function} attachmentCallback A callback that receives information about attachment
 	 *     save progress. The callback will be called as attachmentCallback(attachment, false, error)
 	 *     on failure or attachmentCallback(attachment, progressPercent) periodically during saving.
@@ -435,6 +436,7 @@ Zotero.Translate.ItemSaver.prototype = {
 	 */
 	_saveAttachmentsToServer: function(itemKey, baseName, attachments, prefs, attachmentCallback=()=>0) {
 		var promises = [];
+		attachments = Zotero.Utilities.filterAttachmentsToSave(attachments);
 		for (let attachment of attachments) {
 			let isSnapshot = false;
 			if (attachment.mimeType) {
@@ -445,11 +447,6 @@ Zotero.Translate.ItemSaver.prototype = {
 				}
 			}
 
-			if ((isSnapshot && !prefs.automaticSnapshots) || (!isSnapshot && !prefs.downloadAssociatedFiles)) {
-				// Skip attachment due to prefs
-				continue;
-			}
-			
 			let deferredHeadersProcessed = Zotero.Promise.defer();
 			let itemKeyPromise = deferredHeadersProcessed.promise
 				.then(() => this._createAttachmentItem(itemKey, attachment));

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -252,8 +252,8 @@ var Zotero = global.Zotero = new function() {
 		Zotero.Connector_Types.init();
 		Zotero.Schema.init();
 		await this._initDateFormatsJSON();
-		Zotero.Prefs.loadNamespace(['translators.', 'downloadAssociatedFiles', 'automaticSnapshots',
-			'reportTranslationFailure', 'capitalizeTitles']);
+		Zotero.Prefs.loadNamespace(['translators.', 'automaticAttachmentTypes',
+			'automaticAttachmentTypes.order', 'reportTranslationFailure', 'capitalizeTitles']);
 		await Zotero.Prefs.loadNamespace('debug');
 		
 		Zotero.Debug.init();
@@ -264,8 +264,8 @@ var Zotero = global.Zotero = new function() {
 	this.initTranslateSandbox = async function() {
 		this.version = await Zotero.TranslateSandbox.sendMessage('getVersion');
 		await this._initDateFormatsJSON();
-		await Zotero.Prefs.loadNamespace(['translators.', 'downloadAssociatedFiles', 'automaticSnapshots',
-			'reportTranslationFailure', 'capitalizeTitles']);
+		await Zotero.Prefs.loadNamespace(['translators.', 'automaticAttachmentTypes',
+			'automaticAttachmentTypes.order', 'reportTranslationFailure', 'capitalizeTitles']);
 	};
 
 	this._initDateFormatsJSON = async function() {
@@ -362,8 +362,8 @@ Zotero.Prefs = new function() {
 		"debug.level": 5,
 		"debug.time": false,
 		"lastVersion": "",
-		"downloadAssociatedFiles": true,
-		"automaticSnapshots": true, // only affects saves to zotero.org. saves to client governed by pref in the client
+		"automaticAttachmentTypes": "pdf,epub,html",
+		"automaticAttachmentTypes.order": "pdf,epub,html",
 		"connector.repo.lastCheck.localTime": 0,
 		"connector.repo.lastCheck.repoTime": 0,
 		"connector.url": 'http://127.0.0.1:23119/',

--- a/src/safari/global.js
+++ b/src/safari/global.js
@@ -118,8 +118,7 @@ Zotero.Connector_Browser = new function() {
 			Zotero.Connector_Browser.saveWithTranslator(tab,
 				tab.translators[0].translatorID, {fallbackOnFailure: true});
 		} else {
-			var withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.automaticSnapshots :
-				Zotero.Prefs.get('automaticSnapshots');
+			var withSnapshot = Zotero.Connector.automaticSnapshots;
 			Zotero.Connector_Browser.saveAsWebpage(tab, { snapshot: withSnapshot });
 		}
 	}
@@ -309,8 +308,7 @@ Zotero.Connector_Browser = new function() {
 	}
 
 	function _showWebpageIcon() {
-		let withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.automaticSnapshots :
-			Zotero.Prefs.get('automaticSnapshots');
+		let withSnapshot = Zotero.Connector.automaticSnapshots;
 		let image = Zotero.ItemTypes.getImageSrc("webpage-gray").replace('images/', 'images/toolbar/')
 			.replace(`${safari.extension.baseURI}safari/`, '');
 		let tooltip = `"Save to Zotero (Web Page with${withSnapshot ? "" : "out"} Snapshot)"`;

--- a/src/safari/popoverTranslatorSelector.html
+++ b/src/safari/popoverTranslatorSelector.html
@@ -86,8 +86,7 @@
 				li.parentNode.removeChild(li);
 			}
 
-			var withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.automaticSnapshots :
-				Zotero.Prefs.get('automaticSnapshots');
+			var withSnapshot = Zotero.Connector.automaticSnapshots;
 			if (withSnapshot) {
 				document.getElementsByTagName('menu')[0]
 					.insertBefore(saveWithSnapshotElem, saveWithoutSnapshotElem);


### PR DESCRIPTION
With only basic support for direct-to-zotero.org translation right now - can enable/disable PDF and HTML like before but can't change the priority. That's to avoid needing to reimplement the full preferences UI from the client.

Needs https://github.com/zotero/utilities/pull/34 and https://github.com/zotero/translate/pull/36