### PR TITLE
vpat 53: fix iframe not being scrollable when zoomed in past 300%

### DIFF
--- a/src/common/inject/progressWindow_inject.js
+++ b/src/common/inject/progressWindow_inject.js
@@ -244,7 +244,9 @@ if (isTopWindow) {
 			padding: "none",
 			margin: "initial",
 			zIndex: 2147483647,
-			display: 'none'
+			display: 'none',
+			// frame becomes scrollable if the user zooms in (wcag 1.4.10), or half of it will be inaccessible
+			maxHeight: '90vh' 
 		};
 		for (let i in style) iframe.style[i] = style[i];
 		window.top.document.body.appendChild(iframe);

--- a/src/common/progressWindow/progressWindow.css
+++ b/src/common/progressWindow/progressWindow.css
@@ -1,7 +1,3 @@
-html {
-	overflow: hidden;
-}
-
 body {
 	/* Match tree.css */
 	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
@@ -108,6 +104,8 @@ button:active {
 	padding-left: 5px;
 	padding-right: 5px;
 	font-size: 12px;
+	/* Ensures the input can shrink to make space for the done btn if the user zooms into the iframe */
+	min-width: 0; 
 }
 
 .ProgressWindow-button {


### PR DESCRIPTION
One might need to zoom onto the frame to see details better and if they zoom in too much, the bottom half will be outside of the viewport and with no way to scroll to it. This adds a few css tweaks to make the frame itself scrollable if one zooms in so that it does not fully fit into the viewport.

Relevant WCAG criterion: https://www.w3.org/WAI/WCAG21/Understanding/reflow.html

New behavior on zoom in:

https://github.com/user-attachments/assets/98ed7ddc-d293-4ff2-a561-e066b31918da

Vpat issue for reference:

---

Description: Within the desktop extension when testing page reflow it was found that content would be lost with the extension in its expanded state. At 300% the Tags edit field, the Done button, and the text at the bottom of the extension is all lost. This behavior is consistent when page zoom is increased to 400%. 

Impact Statement: People with low vision who need to enlarge text and read it in a single column. When the browser zoom is used to scale content to 400%, it reflows - i.e., it is presented in one column so that scrolling in more than one direction is not necessary. Content can be presented without loss of information or functionality, and without requiring scrolling in two dimensions

Expected Result: Content remains visually accessible during page reflow up to 400% page zoom 

Actual Result: Content becomes lost starting at 300% page zoom 