### PR TITLE
MV3: Support CSL import from all .csl gitee pages

### DIFF
--- a/src/browserExt/contentTypeHandler.js
+++ b/src/browserExt/contentTypeHandler.js
@@ -48,6 +48,7 @@ Zotero.ContentTypeHandler = {
 	mv3CSLWhitelistRegexp: {
 		"https://www.zotero.org/styles/\\1": /https?:\/\/(?:www\.)zotero\.org\/styles\/?#importConfirm=(.*)$/,
 		"https://raw.githubusercontent.com/\\1/\\2": /https?:\/\/github\.com\/([^/]*\/[^/]*)\/[^/]*\/([^.]*.csl)#importConfirm$/,
+		"https://gitee.com/\\1/raw/\\2": /https?:\/\/gitee\.com\/([^/]+\/[^/]+)\/blob\/(.+\.csl)$/
 	},
 	ignoreURL: new Set(),
 	
@@ -137,15 +138,14 @@ Zotero.ContentTypeHandler = {
 	},
 
 	_isImportableStyle: function (url, contentType) {
-		const URI = new URL(url);
 		// Offer to install CSL by Content-Type
 		if (Zotero.ContentTypeHandler.cslContentTypes.has(contentType)) {
 			return true;
 		}
 		// Offer to install CSL if URL path ends with .csl and host is allowed
-		else if (URI.pathname.match(/\.csl$/)) {
+		else if (/\.csl$/i.test(url)) {
 			let hosts = Zotero.Prefs.get('allowedCSLExtensionHosts');
-			if (Array.isArray(hosts) && hosts.includes(URI.hostname)) {
+			if (Array.isArray(hosts) && hosts.some(host => new RegExp(host).test(url))) {
 				return true;
 			}
 		}

--- a/src/browserExt/contentTypeHandler.js
+++ b/src/browserExt/contentTypeHandler.js
@@ -48,7 +48,7 @@ Zotero.ContentTypeHandler = {
 	mv3CSLWhitelistRegexp: {
 		"https://www.zotero.org/styles/\\1": /https?:\/\/(?:www\.)zotero\.org\/styles\/?#importConfirm=(.*)$/,
 		"https://raw.githubusercontent.com/\\1/\\2": /https?:\/\/github\.com\/([^/]*\/[^/]*)\/[^/]*\/([^.]*.csl)#importConfirm$/,
-		"https://gitee.com/\\1/raw/\\2": /https?:\/\/gitee\.com\/([^/]+\/[^/]+)\/blob\/(.+\.csl)$/
+		"https://gitee.com/\\1/raw/\\2": /https?:\/\/gitee\.com\/([^/]+\/[^/]+)\/blob\/(.+\.csl)#importConfirm$/
 	},
 	ignoreURL: new Set(),
 	

--- a/src/browserExt/styleInterceptRules.json
+++ b/src/browserExt/styleInterceptRules.json
@@ -26,5 +26,19 @@
 			"regexFilter": "^https://raw\\.githubusercontent\\.com/([^/]*/[^/]*)/([^/]*/[^#?]+.csl)$",
 			"resourceTypes": ["main_frame"]
 		}
+	},
+	{
+		"id": 3,
+		"priority": 1,
+		"action": {
+			"type": "redirect",
+			"redirect": {
+				"regexSubstitution": "https://gitee.com/\\1/blob/\\2"
+			}
+		},
+		"condition": {
+			"regexFilter": "^https://gitee\\.com/([^/]+/[^/]+)/raw/(.+\\.csl)$",
+			"resourceTypes": ["main_frame"]
+		}
 	}
 ]

--- a/src/browserExt/styleInterceptRules.json
+++ b/src/browserExt/styleInterceptRules.json
@@ -33,7 +33,7 @@
 		"action": {
 			"type": "redirect",
 			"redirect": {
-				"regexSubstitution": "https://gitee.com/\\1/blob/\\2"
+				"regexSubstitution": "https://gitee.com/\\1/blob/\\2#importConfirm"
 			}
 		},
 		"condition": {

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -374,7 +374,7 @@ Zotero.Prefs = new function() {
 		"connector.url": 'http://127.0.0.1:23119/',
 		"capitalizeTitles": false,
 		"interceptKnownFileTypes": true,
-		"allowedCSLExtensionHosts": ["raw.githubusercontent.com"],
+		"allowedCSLExtensionHosts": ["^https://raw\\.githubusercontent\\.com/", "^https://gitee\\.com/.+/raw/"],
 		"allowedInterceptHosts": [],
 		"firstUse": true,
 		"firstSaveToServer": true,


### PR DESCRIPTION
1. Github is often inaccessible in Chinese Mainland due to unaudited political content.
2. In China, Gitee, also based on Git, is widely used as an alternative to GitHub.

Most East Asian style rely on [CSL-M](https://juris-m.github.io/cslm-docs/) to achieve, and these styles are not allowed to be merged into CSL Syle's repository, though some are popular. We have maintained [a large number of such styles](https://github.com/zotero-chinese/styles/tree/main/src) and synchronized them to [Gitee](https://gitee.com/redleafnew00/Chinese-STD-GB-T-7714-related-csl). In order to facilitate their distribution (as well as other styles that may be hosted on Gitee), I made this request.

- Dev Evn: WSL Ubuntu 22
- Tested on:  Microsoft Edge