### PR TITLE
Update testrunner for Firefox

### DIFF
--- a/test/seleniumTests.js
+++ b/test/seleniumTests.js
@@ -137,14 +137,7 @@ if ('TEST_FX' in process.env) {
 				.setFirefoxOptions(options)
 				.build();
 
-			await driver.setContext(firefox.Context.CHROME);
-			await driver.executeScript(`
-				var prefBranch = Services.prefs.getBranch("");
-				prefBranch.setBoolPref('xpinstall.signatures.required', false);
-			`);
-			await driver.setContext(firefox.Context.CONTENT);
-
-			let uuid = await driver.installAddon('/tmp/zoteroConnector.xpi');
+			let uuid = await driver.installAddon('/tmp/zoteroConnector.xpi', true);
 			// Doing some crazy xpath matching since extId cannot be retrieved by API
 			// Sigh. This is bound to break eventually
 			let extIdXPath = `//dd[text()="${uuid}"]/../following-sibling::div/dd`;


### PR DESCRIPTION
This patch gets tests running on firefox 131. We install the addon in temporary mode and drop the preference hack.

### Issue
Firefox test run fails with

```
WebDriverError: Could not install add-on
```

### Changes
1. Install addon in temporary mode
- Tested in Firefox 131 =>  fixes issue
2. Remove broken `xpinstall.signatures.required` code
- Tested in Firefox 131 => fix remains stable

### Docs
- [Selenium Docs: Add-ons: Unsigned installation](https://www.selenium.dev/documentation/webdriver/browsers/firefox/#add-ons)
