### PR TITLE
Add note field to progress window

### DIFF
--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -72,6 +72,7 @@ Zotero.Connector = new function() {
 			Zotero.Connector.googleDocsAddNoteEnabled = !!response.prefs.googleDocsAddNoteEnabled;
 			Zotero.Connector.googleDocsCitationExplorerEnabled = !!response.prefs.googleDocsCitationExplorerEnabled;
 			Zotero.Connector.supportsAttachmentUpload = !!response.prefs.supportsAttachmentUpload;
+			Zotero.Connector.canUserAddNote = !!response.prefs.canUserAddNote;
 			if (response.prefs.translatorsHash) {
 				(async () => {
 					let sorted = !!response.prefs.sortedTranslatorHash;

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -641,6 +641,7 @@ let PageSaving = {
 	 * @param {Boolean} data.resaveAttachments - Whether attachments should be resaved
 	 * @param {Boolean} data.removeAttachments - Whether attachments should be removed
 	 * @param {String[]} data.tags - A list of tags
+	 * @param {String[]} data.note - A child note to add to the items
 	 */
 	async onUpdateSession(data) {
 		// This message is received in every frame from the progress window
@@ -652,7 +653,8 @@ let PageSaving = {
 			{
 				sessionID: this.sessionDetails.id,
 				target: data.target,
-				tags: data.tags
+				tags: data.tags,
+				note: data.note
 			}
 		);
 

--- a/src/common/inject/progressWindow_inject.js
+++ b/src/common/inject/progressWindow_inject.js
@@ -59,7 +59,7 @@ if (isTopWindow) {
 	var isFilesEditable = false;
 	var syncDelayIntervalID;
 	var insideIframe = false;
-	var insideTags = false;
+	var closeTimerDisabled = false;
 	var blurred = false;
 	var frameSrc;
 	var frameIsHidden = false;
@@ -216,7 +216,7 @@ if (isTopWindow) {
 	function startCloseTimer(delay) {
 		// Don't start the timer if the mouse is over the popup or the tags box has focus
 		if (insideIframe) return;
-		if (insideTags) return;
+		if (closeTimerDisabled) return;
 		
 		if (!delay) delay = 5000;
 		stopCloseTimer();
@@ -305,6 +305,7 @@ if (isTopWindow) {
 					{
 						target: data.target.id,
 						tags: data.tags,
+						note: data.note.replace(/\n/g, "<br>"), // replace newlines with <br> for note-editor
 						resaveAttachments: !lastSuccessfulTarget.filesEditable && data.target.filesEditable,
 						removeAttachments: lastSuccessfulTarget.filesEditable && !data.target.filesEditable
 					}
@@ -347,8 +348,8 @@ if (isTopWindow) {
 		addMessageListener('progressWindowIframe.mouseenter', handleMouseEnter);
 		addMessageListener('progressWindowIframe.mouseleave', handleMouseLeave);
 		
-		addMessageListener('progressWindowIframe.tagsfocus', () => insideTags = true);
-		addMessageListener('progressWindowIframe.tagsblur', () => insideTags = false);
+		addMessageListener('progressWindowIframe.disableCloseTimer', () => closeTimerDisabled = true);
+		addMessageListener('progressWindowIframe.enableCloseTimer', () => closeTimerDisabled = false);
 		
 		addMessageListener('progressWindowIframe.blurred', async function() {
 			blurred = true;

--- a/src/common/progressWindow/progressWindow.css
+++ b/src/common/progressWindow/progressWindow.css
@@ -108,6 +108,20 @@ button:active {
 	min-width: 0; 
 }
 
+.ProgressWindow-noteEditor {
+	width: 100%;
+	resize: none;
+	max-height: 6em; /* expand up to 5 lines of text */
+	height: 34px; /* initial height that may increase as user types */
+	font-family: inherit;
+	font-size: 12px;
+}
+
+.ProgressWindow-noteEditorRow {
+	margin-top: 6px;
+	display: flex;
+}
+
 .ProgressWindow-button {
 	background-color: white;
 	padding: 3px 24px;

--- a/src/messages.json
+++ b/src/messages.json
@@ -118,6 +118,9 @@
 	"progressWindow_filterPlaceholder": {
 		"message": "Filter Collections"
 	},
+	"progressWindow_noteEditorPlaceholder": {
+		"message": "Add a note"
+	},
 	"progressWindow_error_translation": {
 		"message": "An error occurred while saving this item. See $1 for more information."
 	},


### PR DESCRIPTION
So one can add a child note to items that are being saved. 

- if client passes `canUserAddNote` flag in ping response, display a textarea note field above tag selector
- the window will remain open if the focus is in the textarea, same as with tags
- on blur, note content is passed to the client to save as a child note
- Enter from the note field will add a new line. Shift-Enter can close the dialog.

Needs: https://github.com/zotero/zotero/pull/5064
Fixes: #376

Brief demo: https://www.dropbox.com/scl/fi/k7jm6uc3t4syve2vs8z6a/connector_note_demo.mov?rlkey=3h91ujz6qzeyzyd72nsv50uyw&st=gyuac1x4

