### PR TITLE
Fetch attachments in Connector and pass to Zotero on save

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,6 +128,7 @@ var backgroundInclude = [
 	'translate/debug.js',
 	'translate/tlds.js',
 	'translate/translator.js',
+	'itemSaver_background.js',
 	'translators.js',
 	'cachedTypes.js',
 	'errors_webkit.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -151,6 +151,7 @@ var backgroundIncludeBrowserExt = ['browser-polyfill.js'].concat(backgroundInclu
 	'contentTypeHandler.js',
 	'saveWithoutProgressWindow.js',
 	'messagingGeneric.js',
+	'browserAttachmentMonitor/browserAttachmentMonitor.js',
 	'offscreen/offscreenFunctionOverrides.js', 'background/offscreenManager.js',
 ]);
 

--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -1024,7 +1024,7 @@ Zotero.Connector_Browser = new function() {
 		);
 	}
 	
-	this.saveAsWebpage = function(tab, frameId, options) {
+	this.saveAsWebpage = function(tab, frameId, options={}) {
 		let tabInfo = this.getTabInfo(tab.id);
 		if (tabInfo.uninjectable) {
 			return Zotero.Utilities.saveWithoutProgressWindow(tab, frameId);

--- a/src/browserExt/browserAttachmentMonitor/browserAttachmentMonitor.html
+++ b/src/browserExt/browserAttachmentMonitor/browserAttachmentMonitor.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2025 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+					http://zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+-->
+
+<!-- This is just a starting point so we can detect the iframe where we'll attempt to fetch the attachment 
+	and then we redirect to the actual attachment url -->
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+	<script src="../browser-polyfill.js"></script>
+	<script src="browserAttachmentMonitor_inject.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/src/browserExt/browserAttachmentMonitor/browserAttachmentMonitor.js
+++ b/src/browserExt/browserAttachmentMonitor/browserAttachmentMonitor.js
@@ -1,0 +1,132 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2025 Corporation for Digital Scholarship
+					Vienna, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+Zotero.BrowserAttachmentMonitor = {
+	_downloads: new Map(),
+	_nextRuleId: 50000,
+	
+	init: function() {
+		// browser.declarativeNetRequest.onRuleMatchedDebug.addListener((details) => {
+		// 	console.log("DNR rule matched:", details);
+		// });
+	},
+
+	waitForAttachment: async function(tabId, timeoutMs=60000) {
+
+		const ruleId = this._nextRuleId++;
+
+		// Create promise that will resolve when attachment is found
+		let resolveSucceeded;
+		const successPromise = new Promise(resolve => {
+			resolveSucceeded = resolve;
+		});
+
+		// Setup message listener for success notification
+		const messageListener = (message, sender) => {
+			if (sender.tab.id === tabId 
+				&& message.type === 'attachment-monitor-loaded'
+				&& message.success) {
+					Zotero.debug(`BrowserAttachmentMonitor: Attachment successfully loaded for tab: ${tabId}`);
+					resolveSucceeded(message.success);
+					this._cleanup(ruleId, messageListener, tabRemovedListener);
+			}
+		};
+
+		// Setup tab removal listener for this specific tab
+		const tabRemovedListener = (removedTabId) => {
+			if (removedTabId === tabId) {
+				this._cleanup(ruleId, messageListener, tabRemovedListener);
+			}
+		};
+		browser.runtime.onMessage.addListener(messageListener);
+		browser.tabs.onRemoved.addListener(tabRemovedListener);
+
+		try {
+			// Add DNR rule and wait for success or timeout
+			await this._addDNRRule(tabId, ruleId);
+			
+			return await Promise.race([
+				successPromise,
+				Zotero.Promise.delay(timeoutMs).then(() => { 
+					Zotero.debug(`Attachment monitor timed out after ${timeoutMs} ms for tab: ${tabId}`);
+					throw new Error('Attachment monitor timed out'); 
+				})
+			]);
+		}
+		finally {
+			this._cleanup(ruleId, messageListener, tabRemovedListener);
+		}
+	},
+
+	_cleanup: async function(ruleId, messageListener, tabRemovedListener) {
+		// Remove listeners
+		if (messageListener) {
+			browser.runtime.onMessage.removeListener(messageListener);
+		}
+		if (tabRemovedListener) {
+			browser.tabs.onRemoved.removeListener(tabRemovedListener);
+		}
+
+		// Remove DNR rule
+		if (ruleId) {
+			await chrome.declarativeNetRequest.updateDynamicRules({
+				removeRuleIds: [ruleId]
+			});
+		}
+	},
+	
+	_addDNRRule: async function(tabId, ruleId) {
+		const redirectUrl = Zotero.getExtensionURL("browserAttachmentMonitor/browserAttachmentMonitor.html#success=\\0");
+		await chrome.declarativeNetRequest.updateSessionRules({
+			removeRuleIds: [ruleId],
+			addRules: [{
+				id: ruleId,
+				action: {
+					type: 'redirect',
+					redirect: {
+						regexSubstitution: redirectUrl
+					}
+				},
+				condition: {
+					regexFilter: '.*',
+					tabIds: [tabId],
+					responseHeaders: [
+						{
+							header: 'content-disposition',
+							values: ['*attachment*']
+						},
+						{
+							header: 'content-type',
+							values: ['application/pdf', 'application/epub+zip']
+						}
+					]
+				}
+			}]
+		});
+	}
+};
+
+// Initialize when the module loads
+Zotero.BrowserAttachmentMonitor.init();

--- a/src/browserExt/browserAttachmentMonitor/browserAttachmentMonitor_inject.js
+++ b/src/browserExt/browserAttachmentMonitor/browserAttachmentMonitor_inject.js
@@ -1,0 +1,19 @@
+(async function() {
+	window.addEventListener('load', async () => {
+		const match = /success=(.*)/.exec(window.location.hash);
+		const success = match ? match[1] : false;
+		try {
+			await browser.runtime.sendMessage({
+				type: 'attachment-monitor-loaded',
+				success
+			});
+		}
+		catch (e) { }
+		// Sanity wait for DNR to be updated in the background
+		await new Promise(resolve => setTimeout(resolve, 200));
+		const urlMatch = new URLSearchParams(window.location.hash.slice(1)).get('url');
+		if (urlMatch) {
+			window.location.href = decodeURIComponent(urlMatch);
+		}
+	});
+})(); 

--- a/src/browserExt/manifest-v3.json
+++ b/src/browserExt/manifest-v3.json
@@ -59,6 +59,7 @@
 			"progressWindow/progressWindow.html",
 			"modalPrompt/modalPrompt.html",
 			"test/data/journalArticle-single.html",
+			"browserAttachmentMonitor/browserAttachmentMonitor.html",
 			"lib/SingleFile/single-file-hooks-frames.js",
 			"inject/pageSaving.js",
 			"translateWeb.js",

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -12,8 +12,11 @@
 		},
 		"default_title": "Save to Zotero"
 	},
-	"permissions": ["http://*/*", "https://*/*", "tabs", "contextMenus", "cookies", 
-		"webRequest", "webRequestBlocking", "webNavigation", "storage"],
+	"permissions": [
+		"http://*/*", "https://*/*",
+		"tabs", "contextMenus", "cookies", "storage", "scripting",
+		"webRequest", "webRequestBlocking", "webNavigation", "declarativeNetRequest"
+	],
 	"optional_permissions": ["management", "clipboardWrite"],
 	"background": {
 		"scripts": [

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -49,6 +49,7 @@
 		"images/*",
 		"progressWindow/progressWindow.html",
 		"modalPrompt/modalPrompt.html",
+		"browserAttachmentMonitor/browserAttachmentMonitor.html",
 		"test/data/journalArticle-single.html",
 		"lib/SingleFile/single-file-hooks-frames.js",
 		"inject/pageSaving.js",

--- a/src/browserExt/messagingGeneric.js
+++ b/src/browserExt/messagingGeneric.js
@@ -97,7 +97,7 @@ Zotero.MessagingGeneric = class {
 		}
 		// And handler function overrides towards us
 		for (let fnName in this._handlerFunctionOverrides) {
-			this.addMessageListener(fnName, async (args) => {
+			this.addMessageListener(fnName, async (args = []) => {
 				const fnPath = fnName.split('.');
 				const messageConfig = this._handlerFunctionOverrides[fnName];
 				let result;

--- a/src/browserExt/webRequestIntercept.js
+++ b/src/browserExt/webRequestIntercept.js
@@ -151,16 +151,7 @@ Zotero.WebRequestIntercept = {
 	
 	replaceHeaders: async function(url, headers) {
 		if (!Zotero.isBrowserExt) return;
-		if (Zotero.isManifestV3 && Zotero.isChromium) return this.replaceHeadersDNR(url, headers);
-			function headerReplacer(details) {
-				if (details.url === url) {
-					browser.webRequest.onBeforeSendHeaders.removeListener(headerReplacer);
-					Zotero.debug(`Replacing headers for ${url} to ${JSON.stringify(headers)}`);
-					headers = Object.assign(details.requestHeaders, headers);
-					return { requestHeaders: headers };
-				}
-			}
-		browser.webRequest.onBeforeSendHeaders.addListener(headerReplacer, {urls: ['<all_urls>'], types: ['xmlhttprequest']}, ['blocking', 'requestHeaders']);
+		return this.replaceHeadersDNR(url, headers);
 	},
 	
 	replaceHeadersDNR: async function(url, headers) {
@@ -176,7 +167,7 @@ Zotero.WebRequestIntercept = {
 			},
 			condition: {
 				resourceTypes: ['xmlhttprequest'],
-				initiatorDomains: [chrome.runtime.id],
+				initiatorDomains: [new URL(browser.runtime.getURL('')).hostname],
 			}
 		}];
 		try {

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -248,8 +248,6 @@ Zotero.API = new function() {
 	/**
 	 * Uploads an attachment to the Zotero server.
 	 * @param {Object} attachment An attachment object. This object must have the following keys<br>
-	 *     id - a unique identifier for the attachment used to identifiy it in subsequent progress
-	 *          messages<br>
 	 *     data - the attachment contents, as a typed array<br>
 	 *     filename - a filename for the attachment<br>
 	 *     key - the attachment item key<br>
@@ -257,7 +255,7 @@ Zotero.API = new function() {
 	 *     mimeType - the attachment MIME type
 	 */
 	this.uploadAttachment = async function(attachment) {
-		const REQUIRED_PROPERTIES = ["id", "data", "filename", "key", "md5", "mimeType"];
+		const REQUIRED_PROPERTIES = ["data", "key", "md5", "mimeType"];
 		for (const property of REQUIRED_PROPERTIES) {
 			if (!attachment[property]) {
 				throw new Error('Required property "' + property + '" not defined');

--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -61,10 +61,13 @@ Zotero.Connector = new function() {
 	this.ping = async function(payload={}) {
 		let response = await Zotero.Connector.callMethod("ping", payload);
 		if (response && 'prefs' in response) {
+			// TODO refactor this because it's stupid
+			Zotero.Connector.downloadAssociatedFiles = !!response.prefs.downloadAssociatedFiles;
 			Zotero.Connector.shouldReportActiveURL = !!response.prefs.reportActiveURL;
 			Zotero.Connector.automaticSnapshots = !!response.prefs.automaticSnapshots;
 			Zotero.Connector.googleDocsAddNoteEnabled = !!response.prefs.googleDocsAddNoteEnabled;
 			Zotero.Connector.googleDocsCitationExplorerEnabled = !!response.prefs.googleDocsCitationExplorerEnabled;
+			Zotero.Connector.supportsAttachmentUpload = !!response.prefs.supportsAttachmentUpload;
 			if (response.prefs.translatorsHash) {
 				(async () => {
 					let sorted = !!response.prefs.sortedTranslatorHash;

--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -25,7 +25,7 @@
 
 // TODO: refactor this class
 Zotero.Connector = new function() {
-	const CONNECTOR_API_VERSION = 2;
+	const CONNECTOR_API_VERSION = 3;
 	
 	var _ieStandaloneIframeTarget, _ieConnectorCallbacks;
 	this.isOnline = (Zotero.isSafari || Zotero.isFirefox) ? false : null;

--- a/src/common/errors_webkit.js
+++ b/src/common/errors_webkit.js
@@ -30,7 +30,14 @@ Zotero.Errors = new function() {
 		if (Zotero.isManifestV3) {
 			let storedData = await browser.storage.session.get({'loggedErrors': []});
 			_output = storedData.loggedErrors.concat(_output);
+			if (!_output.length) {
+				_output.push('Info: Service worker starts: ');
+			}
 		}
+	}
+	
+	this.logServiceWorkerStarts = function(time) {
+		_output[0] = _output[0] += ` ${time}`
 	}
 	
 	/**
@@ -42,13 +49,7 @@ Zotero.Errors = new function() {
 	this.log = function(string, url, line) {
 		// Special case for MV3 service worker restart info logging
 		var err;
-		if (string.startsWith('Service worker')) {
-			err = [`[Info: ${string}`];
-			url = line = null;
-		}
-		else {
-			err = [`[JavaScript Error: "${string}"`];
-		}
+		err = [`[JavaScript Error: "${string}"`];
 		if(url || line) {
 			var info = [];
 			if(url) info.push('file: "'+url+'"');

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -76,6 +76,8 @@ Zotero.HTTP = new function() {
 	 *         <li>successCodes - HTTP status codes that are considered successful, or FALSE to allow all</li>
 	 *         <li>maxBackoff - how many times should a HTTP 429 backoff be attempted before the request fails
 	 *         		[default 0]</li>
+	 *         <li>forceInject - force the request to be sent via the inject script, even if it's not a same-origin request
+	 *         		[default false]</li>
 	 *     </ul>
 	 * @return {Promise<XMLHttpRequest>} A promise resolved with the XMLHttpRequest object if the
 	 *     request succeeds, or rejected if the browser is offline or a non-2XX status response
@@ -94,6 +96,7 @@ Zotero.HTTP = new function() {
 			successCodes: null,
 			maxBackoff: 10,
 			backoff: 0,
+			forceInject: false,
 		}, options);
 		let originalOptions = Zotero.Utilities.deepCopy(options);
 		
@@ -142,7 +145,7 @@ Zotero.HTTP = new function() {
 		// the background page since we're unable to replace user-agent via an on-page xhr and
 		// since user-agent option is explicitly set, it takes priority.
 		let sameOriginRequestViaSafari = Zotero.isSafari && Zotero.HTTP.isSameOrigin(url) && !options.headers['User-Agent'];
-		if (Zotero.isInject && !sameOriginRequestViaSafari) {
+		if (Zotero.isInject && !options.forceInject && !sameOriginRequestViaSafari) {
 			// The privileged XHR that Firefox makes available to content scripts so that they
 			// can make cross-domain requests doesn't include the Referer header in requests [1],
 			// so sites that check for it don't work properly. As long as we're not making a

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -309,7 +309,7 @@ Zotero.HTTP = new function() {
 				if (options.body != null) {
 					throw new Error(`HTTP ${method} cannot have a request body (${options.body})`)
 				}
-			} else if(options.body) {
+			} else if (options.body && !(options.body instanceof ArrayBuffer)) {
 				if (options.headers["Content-Type"] !== 'multipart/form-data') {
 					options.body = typeof options.body == 'string' ? options.body : JSON.stringify(options.body);
 

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -25,7 +25,7 @@
 
 const MAX_BACKOFF = 64e3;
 
-let HEADERS_SPECIAL_HANDLING = ['User-Agent'];
+let HEADERS_SPECIAL_HANDLING = ['User-Agent', 'Cookie'];
 if (Zotero.isChromium) {
 	HEADERS_SPECIAL_HANDLING.push('Referer');
 }
@@ -350,17 +350,16 @@ Zotero.HTTP = new function() {
 			let replaceHeaders = HEADERS_SPECIAL_HANDLING.filter(header => !!options.headers[header])
 				.map(header => {
 					const val = { name: header, value: options.headers[header] }
-					delete options.headers['User-Agent'];
+					delete options.headers[header];
 					return val;
 				});
 			if (replaceHeaders.length) {
 				DNRRuleID = await Zotero.WebRequestIntercept.replaceHeaders(url, replaceHeaders);
 			}
-			let headers = new Headers(options.headers);
 			try {
 				let fetchOptions = {
 					method,
-					headers,
+					headers: options.headers,
 					body: options.body,
 					credentials: Zotero.isInject ? 'same-origin' : 'include',
 				}

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -25,10 +25,7 @@
 
 const MAX_BACKOFF = 64e3;
 
-let HEADERS_SPECIAL_HANDLING = ['User-Agent', 'Cookie'];
-if (Zotero.isChromium) {
-	HEADERS_SPECIAL_HANDLING.push('Referer');
-}
+const HEADERS_SPECIAL_HANDLING = ['User-Agent', 'Cookie', 'Referer'];
 
 /**
  * Functions for performing HTTP requests, both via XMLHTTPRequest and using a hidden browser
@@ -220,6 +217,9 @@ Zotero.HTTP = new function() {
 		}	
 		
 		if (Zotero.isBackground) {
+			if (options.referrer) {
+				options.headers['Referer'] = options.referrer;
+			}
 			let replaceHeaders = HEADERS_SPECIAL_HANDLING.filter(header => !!options.headers[header])
 				.map(header => {
 					const val = { name: header, value: options.headers[header] }

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -197,7 +197,7 @@ Zotero.HTTP = new function() {
 			if (options.body != null) {
 				throw new Error(`HTTP ${method} cannot have a request body (${options.body})`)
 			}
-		} else if(options.body) {
+		} else if(options.body && !(options.body instanceof ArrayBuffer)) {
 			if (options.headers["Content-Type"] !== 'multipart/form-data') {
 				options.body = typeof options.body == 'string' ? options.body : JSON.stringify(options.body);
 

--- a/src/common/inject/inject.jsx
+++ b/src/common/inject/inject.jsx
@@ -124,6 +124,9 @@ Zotero.Inject = {
 				return PageSaving.onSaveAsWebpage(data);
 			}
 		});
+		Zotero.Messaging.addMessageListener('updateSession', (data) => {
+			return PageSaving.onUpdateSession(data);
+		})
 		// add listener to rerun detection on page modifications
 		Zotero.Messaging.addMessageListener("pageModified", Zotero.Utilities.debounce(function() {
 			PageSaving.onPageLoad(true);

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -320,7 +320,9 @@ let PageSaving = {
 		var result = await Zotero.Inject.checkActionToServer();
 		if (!result) return;
 
-		if (document.contentType !== 'text/html') {
+		const supportsAttachmentUpload = await Zotero.Connector.getPref('supportsAttachmentUpload');
+
+		if (document.contentType !== 'text/html' && supportsAttachmentUpload) {
 			return await this._saveAsStandaloneAttachment({title, saveSnapshot});
 		}
 		return await this._saveAsWebpage({title, saveSnapshot});

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -481,7 +481,8 @@ let PageSaving = {
 			url: document.location.toString(),
 			mimeType: document.contentType,
 			title,
-			linkMode: "imported_url"
+			linkMode: "imported_url",
+			referrer: document.referrer
 		}
 
 		try {

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -411,21 +411,10 @@ let PageSaving = {
 		} catch (e) {
 			// Client unavailable
 			if (e.status === 0) {
-				let itemSaver = new Zotero.Translate.ItemSaver({});
+				let itemSaver = new ItemSaver({});
 				this.sessionDetails.itemSaver = itemSaver;
-				let items = await itemSaver.saveAsWebpage();
-				if (items.length) {
-					Zotero.Messaging.sendMessage(
-						"progressWindow.itemProgress",
-						{
-							id: title,
-							iconSrc: Zotero.ItemTypes.getImageSrc(image),
-							title,
-							parentItem: false,
-							progress: 100
-						}
-					);
-				}
+				await itemSaver.saveAsWebpage();
+				Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...items[0], progress: 100 });
 				Zotero.Messaging.sendMessage("progressWindow.done", [true]);
 				return;
 			}

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -444,6 +444,10 @@ let PageSaving = {
 
 	async _saveAsStandaloneAttachment({ title=document.title } = {}) {
 		const sessionID = this.sessionDetails.id;
+		// document.title is empty on Safari
+		if (!title) {
+			title = new URL(document.location.href).pathname.split('/').pop();
+		}
 		let itemType = "webpage";
 		if (document.contentType === 'application/pdf') {
 			itemType = "pdf"
@@ -475,6 +479,7 @@ let PageSaving = {
 		}
 
 		try {
+			await ItemSaver.fetchAttachmentSafari(standaloneAttachment);
 			let { canRecognize } = await Zotero.ItemSaver.saveStandaloneAttachmentToZotero(standaloneAttachment, sessionID)
 			Zotero.Messaging.sendMessage("progressWindow.sessionCreated", { sessionID });
 			progressItem.progress = 100;
@@ -486,8 +491,10 @@ let PageSaving = {
 					item.id = 2;
 					item.iconSrc = Zotero.ItemTypes.getImageSrc(item.itemType);
 					progressItem.parentItem = 2;
-					await Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...item, ...{ progress: 100 } });
-					Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...progressItem, ...{ progress: 100 } });
+					Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...item, ...{ progress: 100 } });
+					setTimeout(() => {
+						Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...progressItem, ...{ progress: 100 } });
+					}, 50);
 				}
 			}
 

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -374,7 +374,7 @@ let PageSaving = {
 			}
 			// Once snapshot item is created, if requested, run SingleFile
 			if (isSingleFileAvailable) {
-				var snapshotItem = items[0].attachments = [{
+				items[0].attachments = [{
 					sessionID,
 					id: 2,
 					iconSrc: Zotero.ItemTypes.getImageSrc("attachment-snapshot"),
@@ -384,6 +384,7 @@ let PageSaving = {
 					itemType: Zotero.getString("itemType_snapshot"),
 					itemsLoaded: 1
 				}]
+				let snapshotItem = items[0].attachments[0];
 
 				Zotero.Messaging.sendMessage("progressWindow.itemProgress", snapshotItem);
 

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -367,7 +367,7 @@ let PageSaving = {
 			items[0] = { ...items[0], progress: 100, itemsLoaded: 1 };
 			Zotero.Messaging.sendMessage("progressWindow.itemProgress", items[0]);
 
-			let isSingleFileAvailable = true;
+			let isSingleFileAvailable = document.contentType === "text/html";
 			// SingleFile does not work in Chromium incognito due to object passing via object URL not being available
 			if (Zotero.isChromium && await Zotero.Connector_Browser.isIncognito()){
 				isSingleFileAvailable = false;

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -126,6 +126,9 @@ let PageSaving = {
 	},
 
 	_initSession(translatorID, saveOptions) {
+		if (!saveOptions.resave && this.sessionDetails.id) {
+			return this.sessionDetails.id;
+		}
 		const sessionID = Zotero.Utilities.randomString();
 		this.sessionDetails = {
 			id: sessionID,
@@ -171,14 +174,30 @@ let PageSaving = {
 		}
 		return items;
 	},
+	
+	_onAttachmentProgress(attachment, progress) {
+		const sessionID = PageSaving.sessionDetails.id;
+		Zotero.Messaging.sendMessage(
+			"progressWindow.itemProgress",
+			{
+				sessionID,
+				id: attachment.id,
+				iconSrc: determineAttachmentIcon(attachment),
+				title: attachment.title,
+				parentItem: attachment.parentItem,
+				progress,
+				itemType: determineAttachmentType(attachment)
+			}
+		);
+	},
 
 	/**
 	 * Runs translation and attempts to save items to Zotero or Zotero account
-	 * @param sessionID {String}
 	 * @param translators {Array}
 	 * @returns {Promise<*>}
 	 */
-	async translateAndSave(sessionID, translators) {
+	async translateAndSave(translators) {
+		const sessionID = this.sessionDetails.id;
 		let itemsTotal = 0;
 		let itemsSaved = 0;
 		
@@ -190,19 +209,6 @@ let PageSaving = {
 			// If the handler returns a non-undefined value then it is passed
 			// back to the callback due to backwards compat code in translate.js
 			(async () => {
-				try {
-					let response = await Zotero.Connector.callMethod("getSelectedCollection", {});
-					if (response.libraryEditable === false) {
-						return callback([]);
-					}
-				} catch (e) {
-					// Zotero is online but an error occured anyway, so let's log it and display
-					// the dialog just in case
-					if (e.status != 0) {
-						Zotero.logError(e);
-					}
-				}
-
 				if (Zotero.isBrowserExt) {
 					var returnItems = await Zotero.Connector_Browser.onSelect(items);
 				} else {
@@ -237,6 +243,7 @@ let PageSaving = {
 			);
 		};
 		const onTranslatorFallback = (oldTranslator, newTranslator) => {
+			Zotero.debug(`Saving with ${oldTranslator.label} failed. Trying ${newTranslator.label}`);
 			Zotero.Messaging.sendMessage("progressWindow.error",
 				['fallback', oldTranslator.label, newTranslator.label]);
 		}
@@ -276,32 +283,29 @@ let PageSaving = {
 				}
 			}
 		}
-		const onAttachmentProgress = (attachment, progress) => {
-			Zotero.Messaging.sendMessage(
-				"progressWindow.itemProgress",
-				{
-					sessionID,
-					id: attachment.id,
-					iconSrc: determineAttachmentIcon(attachment),
-					title: attachment.title,
-					parentItem: attachment.parentItem,
-					progress,
-					itemType: determineAttachmentType(attachment)
-				}
-			);
-		}
 
 
 		let translate = await this._initTranslate();
 		let options = { translate, translators, onSelect, onItemSaving, onTranslatorFallback };
-		let { items, proxy } = await TranslateWeb.translate(options);
+		try {
+			var { items, proxy } = await TranslateWeb.translate(options);
+		} catch (e) {
+			let translator = translate.translator[0]
+			if (translator.itemType != 'multiple' && options.fallbackOnFailure) {
+				Zotero.Messaging.sendMessage("progressWindow.error", ['fallback', this.translators.at(-1).label, "Save as Webpage"]);
+				Zotero.debug(`Saving with ${translator.label} failed. Falling back to saving as webpage`);
+				return this.saveAsWebpage({ snapshot: true });
+			}
+		}
 		if (Zotero.isManifestV3) {
 			proxy = await translate.getProxy();
 			if (proxy) proxy = new Zotero.Proxy(proxy);
 		}
 		items = this._processNote(items);
+		this.sessionDetails.items = items;
 		let itemSaver = new ItemSaver({sessionID, baseURI: document.location.href, proxy });
-		return itemSaver.saveItems(items, onAttachmentProgress, onItemsSaved)
+		this.sessionDetails.itemSaver = itemSaver;
+		return itemSaver.saveItems(items, PageSaving._onAttachmentProgress, onItemsSaved)
 	},
 
 	/**
@@ -310,24 +314,21 @@ let PageSaving = {
 	 * @param sessionID
 	 * @param title
 	 * @param saveSnapshot
-	 * @param resave
 	 * @returns {Promise<*>}
 	 */
-	async saveAsWebpage({ sessionID, title=document.title, snapshot: saveSnapshot=true, resave=false } = {}) {
+	async saveAsWebpage({ title=document.title, snapshot: saveSnapshot=true } = {}) {
 		var result = await Zotero.Inject.checkActionToServer();
 		if (!result) return;
 
 		if (document.contentType !== 'text/html') {
-			return await this._saveAsStandaloneAttachment({sessionID, title, saveSnapshot});
+			return await this._saveAsStandaloneAttachment({title, saveSnapshot});
 		}
-		return await this._saveAsWebpage({sessionID, title, saveSnapshot});
+		return await this._saveAsWebpage({title, saveSnapshot});
 	},
 	
-	async _saveAsWebpage({ sessionID, title, saveSnapshot } = {}) {
+	async _saveAsWebpage({ title, saveSnapshot } = {}) {
+		const sessionID = this.sessionDetails.id;
 		var translatorID = 'webpage' + (saveSnapshot ? 'WithSnapshot' : '');
-		if (!sessionID) {
-			throw new Error("Trying to save as webpage without session ID");
-		}
 		try {
 			var cookie = document.cookie;
 		} catch (e) {}
@@ -349,42 +350,21 @@ let PageSaving = {
 		}
 
 		Zotero.Messaging.sendMessage("progressWindow.show", [sessionID]);
-		Zotero.Messaging.sendMessage(
-			"progressWindow.itemProgress",
-			{
-				sessionID,
-				id: 1,
-				iconSrc: Zotero.ItemTypes.getImageSrc(image),
-				title: title
-			}
-		);
+		let items = [{
+			sessionID,
+			id: 1,
+			iconSrc: Zotero.ItemTypes.getImageSrc(image),
+			title: title
+		}];
+		this.sessionDetails.items = items;
+		Zotero.Messaging.sendMessage("progressWindow.itemProgress", items[0]);
 
 		try {
 			var result = await Zotero.Connector.callMethodWithCookies("saveSnapshot", data);
 			Zotero.Messaging.sendMessage("progressWindow.sessionCreated", { sessionID });
-			Zotero.Messaging.sendMessage(
-				"progressWindow.itemProgress",
-				{
-					sessionID,
-					id: 1,
-					iconSrc: Zotero.ItemTypes.getImageSrc(image),
-					title,
-					parentItem: false,
-					progress: 100,
-					itemsLoaded: 1
-				}
-			);
+			items[0] = { ...items[0], progress: 100, itemsLoaded: 1 };
+			Zotero.Messaging.sendMessage("progressWindow.itemProgress", items[0]);
 
-			let progressItem = {
-				sessionID,
-				id: 2,
-				iconSrc: Zotero.ItemTypes.getImageSrc("attachment-snapshot"),
-				title: "Snapshot",
-				parentItem: 1,
-				progress: 0,
-				itemType: Zotero.getString("itemType_snapshot"),
-				itemsLoaded: 1
-			};
 			let isSingleFileAvailable = true;
 			// SingleFile does not work in Chromium incognito due to object passing via object URL not being available
 			if (Zotero.isChromium && await Zotero.Connector_Browser.isIncognito()){
@@ -392,31 +372,29 @@ let PageSaving = {
 			}
 			// Once snapshot item is created, if requested, run SingleFile
 			if (isSingleFileAvailable) {
-				Zotero.Messaging.sendMessage("progressWindow.itemProgress", progressItem);
+				var snapshotItem = items[0].attachments = [{
+					sessionID,
+					id: 2,
+					iconSrc: Zotero.ItemTypes.getImageSrc("attachment-snapshot"),
+					title: "Snapshot",
+					parentItem: 1,
+					progress: 0,
+					itemType: Zotero.getString("itemType_snapshot"),
+					itemsLoaded: 1
+				}]
 
-				try {
-					data.snapshotContent = Zotero.Utilities.Connector.packString(await Zotero.SingleFile.retrievePageData());
+				Zotero.Messaging.sendMessage("progressWindow.itemProgress", snapshotItem);
 
-					result = await Zotero.Connector.saveSingleFile({
-							method: "saveSingleFile",
-							headers: {"Content-Type": "application/json"}
-						},
-						data
-					);
+				data.snapshotContent = Zotero.Utilities.Connector.packString(await Zotero.SingleFile.retrievePageData());
 
-					Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...progressItem, ...{ progress: 100 } });
-				}
-				catch (e) {
-					// Swallow error, will fallback to save in client
-					Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...progressItem, ...{ progress: false } });
-				}
-			}
+				result = await Zotero.Connector.saveSingleFile({
+						method: "saveSingleFile",
+						headers: {"Content-Type": "application/json"}
+					},
+					data
+				);
 
-			if (result && result.attachments) {
-				for (let attachment of result.attachments) {
-					progressItem.title = attachment.title;
-					Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...progressItem, ...{ progress: 100 } });
-				}
+				Zotero.Messaging.sendMessage("progressWindow.itemProgress", { ...snapshotItem, progress: 100 });
 			}
 
 			Zotero.Messaging.sendMessage("progressWindow.done", [true]);
@@ -432,6 +410,7 @@ let PageSaving = {
 				// Attempt saving to server if not pdf
 				if (document.contentType != 'application/pdf') {
 					let itemSaver = new Zotero.Translate.ItemSaver({});
+					this.sessionDetails.itemSaver = itemSaver;
 					let items = await itemSaver.saveAsWebpage();
 					if (items.length) {
 						Zotero.Messaging.sendMessage(
@@ -461,10 +440,8 @@ let PageSaving = {
 		}
 	},
 
-	async _saveAsStandaloneAttachment({ sessionID, title=document.title } = {}) {
-		if (!sessionID) {
-			throw new Error("Trying to save as standalone attachment without session ID");
-		}
+	async _saveAsStandaloneAttachment({ title=document.title } = {}) {
+		const sessionID = this.sessionDetails.id;
 		let itemType = "webpage";
 		if (document.contentType === 'application/pdf') {
 			itemType = "pdf"
@@ -483,7 +460,7 @@ let PageSaving = {
 			itemType: Zotero.getString(`itemType_${itemType}`),
 		};
 
-		Zotero.Messaging.sendMessage("progressWindow.show", [sessionID]);
+		Zotero.Messaging.sendMessage("progressWindow.show", [sessionID, null, false, true]);
 		Zotero.Messaging.sendMessage(
 			"progressWindow.itemProgress",
 			progressItem
@@ -575,39 +552,33 @@ let PageSaving = {
 			if (!options.fallbackOnFailure) {
 				translators = translators.slice(0, 1)
 			}
-			let items = await this.translateAndSave(sessionID, translators);
+			let items = await this.translateAndSave(translators);
 			Zotero.Messaging.sendMessage("progressWindow.done", [true]);
 			return items;
 		} catch (e) {
 			Zotero.logError(e);
-			let errorMessage = e.toString();
-			if (translator.itemType != 'multiple' && options.fallbackOnFailure) {
-				Zotero.Messaging.sendMessage("progressWindow.error", ['fallback', this.translators.at(-1).label, "Save as Webpage"]);
-				return this.saveAsWebpage({ sessionID, snapshot: true });
+			// Clear session details on failure, so another save click tries again
+			this._clearSession();
+			// We delay opening the progressWindow for multiple items so we don't have to flash it
+			// for the select dialog. But it comes back to bite us in the butt if a translation
+			// error occurs immediately since the below command will execute before the progressWindow show,
+			// and then the delayed progressWindow.show will pop up another empty progress window.
+			// Cannot have that!
+			await Zotero.Promise.delay(500);
+			const isAccessLimitingTranslator = SITE_ACCESS_LIMIT_TRANSLATORS.has(translator.translatorID);
+			const errorMessage = e.toString();
+			let statusCode = '';
+			try {
+				statusCode = errorMessage.match(/status code ([0-9]{3})/)[1];
+			} catch (e) {}
+			const isHTTPErrorForbidden = statusCode == '403';
+			const isHTTPErrorTooManyRequests = statusCode == '429';
+			if ((isAccessLimitingTranslator && isHTTPErrorForbidden) || isHTTPErrorTooManyRequests) {
+				Zotero.Messaging.sendMessage("progressWindow.done", [false, 'siteAccessLimits', translator.label]);
 			}
 			else {
-				// Clear session details on failure, so another save click tries again
-				this._clearSession();
-				// We delay opening the progressWindow for multiple items so we don't have to flash it
-				// for the select dialog. But it comes back to bite us in the butt if a translation
-				// error occurs immediately since the below command will execute before the progressWindow show,
-				// and then the delayed progressWindow.show will pop up another empty progress window.
-				// Cannot have that!
-				await Zotero.Promise.delay(500);
-				const isAccessLimitingTranslator = SITE_ACCESS_LIMIT_TRANSLATORS.has(translator.translatorID);
-				let statusCode = '';
-				try {
-					statusCode = errorMessage.match(/status code ([0-9]{3})/)[1];
-				} catch (e) {}
-				const isHTTPErrorForbidden = statusCode == '403';
-				const isHTTPErrorTooManyRequests = statusCode == '429';
-				if ((isAccessLimitingTranslator && isHTTPErrorForbidden) || isHTTPErrorTooManyRequests) {
-					Zotero.Messaging.sendMessage("progressWindow.done", [false, 'siteAccessLimits', translator.label]);
-				}
-				else {
-					Zotero.Messaging.sendMessage("progressWindow.done", [false]);
-				}
-			}	
+				Zotero.Messaging.sendMessage("progressWindow.done", [false]);
+			}
 		}
 	},
 
@@ -627,6 +598,46 @@ let PageSaving = {
 		
 		var sessionID = this._initSession(translatorID, options);
 		return await this.saveAsWebpage({sessionID, title, snapshot: options.snapshot, resave: options.resave});
+	},
+
+	/**
+	 * Updates the session with the given data.
+	 * @param {Object} data - The data to update the session with.
+	 * @param {String} data.targetId - The target ID
+	 * @param {Boolean} data.resaveFiles - Whether files should be resaved
+	 * @param {String[]} data.tags - A list of tags
+	 */
+	async onUpdateSession(data) {
+		await Zotero.Connector.callMethod(
+			"updateSession",
+			{
+				sessionID: this.sessionDetails.id,
+				target: data.target,
+				tags: data.tags
+			}
+		);
+
+		if (data.resaveAttachments && this.sessionDetails.itemSaver) {
+			Zotero.Messaging.sendMessage("progressWindow.show", [this.sessionDetails.id]);
+			await this.sessionDetails.itemSaver.saveAttachmentsToZotero(
+				PageSaving._onAttachmentProgress
+			);
+			Zotero.Messaging.sendMessage("progressWindow.done", [true]);
+		}
+		else if (data.removeAttachments) {
+			for (let item of this.sessionDetails.items) {
+				for (let attachment of item.attachments) {
+					Zotero.Messaging.sendMessage(
+						"progressWindow.itemProgress",
+						{
+							sessionID: this.sessionDetails.id,
+							id: attachment.id,
+							progress: -1,
+						}
+					);
+				}
+			}
+		}
 	}
 }
 

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -613,7 +613,8 @@ let PageSaving = {
 	 * Updates the session with the given data.
 	 * @param {Object} data - The data to update the session with.
 	 * @param {String} data.targetId - The target ID
-	 * @param {Boolean} data.resaveFiles - Whether files should be resaved
+	 * @param {Boolean} data.resaveAttachments - Whether attachments should be resaved
+	 * @param {Boolean} data.removeAttachments - Whether attachments should be removed
 	 * @param {String[]} data.tags - A list of tags
 	 */
 	async onUpdateSession(data) {

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -608,6 +608,10 @@ let PageSaving = {
 	 * @param {String[]} data.tags - A list of tags
 	 */
 	async onUpdateSession(data) {
+		// This message is received in every frame from the progress window
+		// iframe due to how messaging is set up, and we need to ignore it
+		// on all but the frame that has sessionDetails.id - is translating.
+		if (!this.sessionDetails.id) return;
 		await Zotero.Connector.callMethod(
 			"updateSession",
 			{

--- a/src/common/inject/progressWindow_inject.js
+++ b/src/common/inject/progressWindow_inject.js
@@ -56,7 +56,7 @@ if (isTopWindow) {
 	var nextSessionUpdateData;
 	
 	var isReadOnly = false;
-	var isFiledEditableOnly = false;
+	var isFilesEditable = false;
 	var syncDelayIntervalID;
 	var insideIframe = false;
 	var insideTags = false;
@@ -150,7 +150,7 @@ if (isTopWindow) {
 			lastSuccessfulTarget = target;
 		}
 		
-		let targets = response.targets.filter(t => !isFiledEditableOnly || t.filesEditable);
+		let targets = response.targets.filter(t => !isFilesEditable || t.filesEditable);
 
 		// TEMP: Make sure libraries have levels (added to client in 5.0.46)
 		if (response.targets) {
@@ -413,9 +413,9 @@ if (isTopWindow) {
 		// (e.g., when displaying the Select Items window) we can skip displaying it
 		frameIsHidden = false;
 		
-		var [sessionID, headline, readOnly, filesEditableOnly] = args;
-		if (typeof filesEditableOnly != "undefined") {
-			isFiledEditableOnly = filesEditableOnly;
+		var [sessionID, headline, readOnly, filesEditable] = args;
+		if (typeof filesEditable != "undefined") {
+			isFilesEditable = filesEditable;
 		}
 		
 		// Reopening existing popup

--- a/src/common/inject/progressWindow_inject.js
+++ b/src/common/inject/progressWindow_inject.js
@@ -56,6 +56,7 @@ if (isTopWindow) {
 	var nextSessionUpdateData;
 	
 	var isReadOnly = false;
+	var isFiledEditableOnly = false;
 	var syncDelayIntervalID;
 	var insideIframe = false;
 	var insideTags = false;
@@ -141,13 +142,16 @@ if (isTopWindow) {
 		}
 		var target = {
 			id,
-			name: response.name
+			name: response.name,
+			filesEditable: response.filesEditable
 		};
 		
 		if (response.libraryEditable) {
 			lastSuccessfulTarget = target;
 		}
 		
+		let targets = response.targets.filter(t => !isFiledEditableOnly || t.filesEditable);
+
 		// TEMP: Make sure libraries have levels (added to client in 5.0.46)
 		if (response.targets) {
 			for (let row of response.targets) {
@@ -157,7 +161,7 @@ if (isTopWindow) {
 			}
 		}
 		
-		changeHeadline(prefix, target, response.targets);
+		changeHeadline(prefix, target, targets);
 	}
 	
 	async function addError() {
@@ -296,14 +300,13 @@ if (isTopWindow) {
 			updatingSession = true;
 			
 			try {
-				await Zotero.Connector.callMethod(
+				await sendMessage(
 					"updateSession",
 					{
-						sessionID: currentSessionID,
 						target: data.target.id,
-						tags: data.tags
-							// TEMP: Avoid crash on leading/trailing comma pre-5.0.57
-							? data.tags.replace(/(^,|,$)/g, '') : data.tags
+						tags: data.tags,
+						resaveAttachments: !lastSuccessfulTarget.filesEditable && data.target.filesEditable,
+						removeAttachments: lastSuccessfulTarget.filesEditable && !data.target.filesEditable
 					}
 				);
 			}
@@ -410,7 +413,10 @@ if (isTopWindow) {
 		// (e.g., when displaying the Select Items window) we can skip displaying it
 		frameIsHidden = false;
 		
-		var [sessionID, headline, readOnly] = args;
+		var [sessionID, headline, readOnly, filesEditableOnly] = args;
+		if (typeof filesEditableOnly != "undefined") {
+			isFiledEditableOnly = filesEditableOnly;
+		}
 		
 		// Reopening existing popup
 		if (currentSessionID) {

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -296,27 +296,18 @@ ItemSaver.prototype = {
 		try {
 			// Check if we can get an OA PDF from Zotero
 			if (typeof item.hasAttachmentResolvers === "undefined") {
-				// Change line for the primary attachment if we're going to look for OA alternatives
-				if (attachment) {
-					attachment.title = Zotero.getString("progressWindow_OA_searching");
-					attachmentCallback(attachment, 0);
-				}
 				item.hasAttachmentResolvers = await Zotero.Connector.callMethod('hasAttachmentResolvers', {
 					sessionID: this._sessionID,
 					itemID: item.id
 				});
 			}
 			if (!item.hasAttachmentResolvers) {
-				if (attachment) {
-					attachment.title = Zotero.getString("progressWindow_OA_notFound");
-					attachmentCallback(attachment, false)
-				}
 				return;
 			}
 
 			if (attachment) {
 				attachment = {
-					title: "Open Access PDF",
+					title: Zotero.getString("progressWindow_OA_searching"),
 					isOpenAccess: true,
 				};
 				attachmentCallback(attachment, 0);

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -146,6 +146,10 @@ ItemSaver.prototype = {
 					if (this._itemType === "multiple" || isChromiumIncognito) {
 						return false;
 					}
+					if (!zoteroSupportsAttachmentUpload) {
+						payload.singleFile = true;
+						attachment.singleFile = true;
+					}
 					this._snapshotAttachment = attachment;
 					this._singleFile = true;
 					// If Zotero doesn't support attachment upload then we need to pass the snapshot

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -490,6 +490,7 @@ ItemSaver.prototype = {
 		}
 		for (var i=0; i<items.length; i++) {
 			var item = items[i], key = resp.success[itemIndices[i]];
+			item.key = key;
 			if (item.attachments && item.attachments.length) {
 				await this._saveAttachmentsToServer(key, this._getFileBaseNameFromItem(item),
 					item.attachments, prefs, attachmentCallback);

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -286,27 +286,27 @@ ItemSaver.prototype = {
 			}
 			if (!item.hasPrimaryAttachment) {
 				if (!shouldAttemptToDownloadOAAttachments) continue;
-				await this.saveOAAttachment(item, attachmentCallback);
+				await this.saveAttachmentFromResolver(item, attachmentCallback);
 			}
 		}
 	},
 	
-	async saveOAAttachment(item, attachmentCallback) {
+	async saveAttachmentFromResolver(item, attachmentCallback) {
 		let attachment = item.attachments.find(a => a.isPrimary);
 		try {
 			// Check if we can get an OA PDF from Zotero
-			if (typeof item.hasAlternativeAttachment === "undefined") {
+			if (typeof item.hasAttachmentResolvers === "undefined") {
 				// Change line for the primary attachment if we're going to look for OA alternatives
 				if (attachment) {
 					attachment.title = "Searching for Open Access files…";
 					attachmentCallback(attachment, 0);
 				}
-				item.hasAlternativeAttachment = await Zotero.Connector.callMethod('hasOAAttachments', {
+				item.hasAttachmentResolvers = await Zotero.Connector.callMethod('hasAttachmentResolvers', {
 					sessionID: this._sessionID,
 					itemID: item.id
 				});
 			}
-			if (!item.hasAlternativeAttachment) {
+			if (!item.hasAttachmentResolvers) {
 				if (attachment) {
 					attachment.title = "No Open Access PDFs found";
 					attachmentCallback(attachment, false)
@@ -322,7 +322,7 @@ ItemSaver.prototype = {
 				attachmentCallback(attachment, 0);
 			}
 			
-			let title = await Zotero.Connector.callMethod('saveOAAttachment', {
+			let title = await Zotero.Connector.callMethod('saveAttachmentFromResolver', {
 				sessionID: this._sessionID,
 				itemID: item.id,
 			});

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -342,7 +342,7 @@ ItemSaver.prototype = {
 			attachmentCallback(attachment, 100);
 		} catch (e) {
 			if (attachment) {
-				attachment.title = Zotero.getString("progressWindow_OA_failedToGetPdf")
+				attachment.title = Zotero.getString("progressWindow_OA_failed")
 				attachmentCallback(attachment, false, e);
 			}
 		}

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -238,6 +238,7 @@ ItemSaver.prototype = {
 					if (PRIMARY_ATTACHMENT_TYPES.has(attachment.mimeType)) {
 						attachment.isPrimary = true;
 					}
+					Zotero.Messaging.addMessageListener("passJSBotDetectionViaHiddenIframe", this._passJSBotDetectionViaHiddenIframe);
 					await Zotero.ItemSaver.saveAttachmentToZotero(attachment, this._sessionID)
 					if (attachment.isPrimary) {
 						item.hasPrimaryAttachment = true;

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -446,9 +446,6 @@ ItemSaver.prototype = {
 	 */
 	_saveToServer: async function (items, attachmentCallback, itemsDoneCallback=()=>0) {
 		var newItems = [], itemIndices = [];
-		try {
-			typedArraysSupported = !!(new Uint8Array(1) && new Blob());
-		} catch(e) {}
 		
 		for(var i=0, n=items.length; i<n; i++) {
 			var item = items[i];

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -298,7 +298,7 @@ ItemSaver.prototype = {
 			if (typeof item.hasAttachmentResolvers === "undefined") {
 				// Change line for the primary attachment if we're going to look for OA alternatives
 				if (attachment) {
-					attachment.title = "Searching for Open Access files…";
+					attachment.title = Zotero.getString("progressWindow_OA_searching");
 					attachmentCallback(attachment, 0);
 				}
 				item.hasAttachmentResolvers = await Zotero.Connector.callMethod('hasAttachmentResolvers', {
@@ -308,7 +308,7 @@ ItemSaver.prototype = {
 			}
 			if (!item.hasAttachmentResolvers) {
 				if (attachment) {
-					attachment.title = "No Open Access PDFs found";
+					attachment.title = Zotero.getString("progressWindow_OA_notFound");
 					attachmentCallback(attachment, false)
 				}
 				return;
@@ -342,7 +342,7 @@ ItemSaver.prototype = {
 			attachmentCallback(attachment, 100);
 		} catch (e) {
 			if (attachment) {
-				attachment.title = "Failed to get Open Access PDF";
+				attachment.title = Zotero.getString("progressWindow_OA_failedToGetPdf")
 				attachmentCallback(attachment, false, e);
 			}
 		}

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -473,8 +473,21 @@ ItemSaver.prototype = {
 		
 		Zotero.debug("Translate: Save to server complete");
 		itemsDoneCallback(items);
-
+		
 		const prefs = await Zotero.Prefs.getAsync(["downloadAssociatedFiles", "automaticSnapshots"])
+
+		for (const item of items) {
+			for (const attachment of item.attachments) {
+				if (attachment.mimeType === 'text/html') {
+					if (prefs.automaticSnapshots) {
+						attachmentCallback(attachment, 0);
+					}
+				}
+				else if (prefs.downloadAssociatedFiles) {
+					attachmentCallback(attachment, 0);
+				}
+			}
+		}
 		for (var i=0; i<items.length; i++) {
 			var item = items[i], key = resp.success[itemIndices[i]];
 			if (item.attachments && item.attachments.length) {
@@ -533,7 +546,6 @@ ItemSaver.prototype = {
 			attachment.linkMode = attachment.snapshot === false ? "linked_url" : "imported_url";
 
 			try {
-				attachmentCallback(attachment, 0);
 				promises.push(ItemSaver.fetchAttachmentSafari(attachment).then(() => Zotero.ItemSaver.saveAttachmentToServer(attachment)));
 				attachmentCallback(attachment, 100);
 			}

--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -92,7 +92,7 @@ ItemSaver.prototype = {
 	 */
 	saveItems: async function (items, attachmentCallback, itemsDoneCallback=()=>0) {
 		try {
-			return this._saveToZotero(items, attachmentCallback, itemsDoneCallback);
+			return await this._saveToZotero(items, attachmentCallback, itemsDoneCallback);
 		}
 		catch (e) {
 			if (e.status == 0) {
@@ -451,7 +451,7 @@ ItemSaver.prototype = {
 	 *     attachmentCallback() will be called with all attachments that will be saved
 	 */
 	_saveToServer: async function (items, attachmentCallback, itemsDoneCallback=()=>0) {
-		var newItems = [], itemIndices = [], typedArraysSupported = false;
+		var newItems = [], itemIndices = [];
 		try {
 			typedArraysSupported = !!(new Uint8Array(1) && new Blob());
 		} catch(e) {}
@@ -464,12 +464,8 @@ ItemSaver.prototype = {
 			}
 			itemIndices[i] = newItems.length;
 			newItems = newItems.concat(Zotero.Utilities.Item.itemToAPIJSON(item));
-			if (typedArraysSupported) {
-				for (let attachment of item.attachments) {
-					attachment.id = Zotero.Utilities.randomString();
-				}
-			} else {
-				item.attachments = [];
+			for (let attachment of item.attachments) {
+				attachment.id = Zotero.Utilities.randomString();
 			}
 		}
 		
@@ -481,25 +477,22 @@ ItemSaver.prototype = {
 		}
 		
 		for (var key in resp.failed) {
-			throw new Error("Save to server failed with " + statusCode + " " + response);
+			throw new Error("Save to server failed with " + response.statusCode + " " + response);
 		}
 		
 		Zotero.debug("Translate: Save to server complete");
-		return Zotero.Prefs.getAsync(["downloadAssociatedFiles", "automaticSnapshots"])
-		.then(function (prefs) {
-			if (typedArraysSupported) {
-				for (var i=0; i<items.length; i++) {
-					var item = items[i], key = resp.success[itemIndices[i]];
-					if (item.attachments && item.attachments.length) {
-						this._saveAttachmentsToServer(key, this._getFileBaseNameFromItem(item),
-							item.attachments, prefs, attachmentCallback);
-					}
-				}
+		itemsDoneCallback(items);
+
+		const prefs = await Zotero.Prefs.getAsync(["downloadAssociatedFiles", "automaticSnapshots"])
+		for (var i=0; i<items.length; i++) {
+			var item = items[i], key = resp.success[itemIndices[i]];
+			if (item.attachments && item.attachments.length) {
+				await this._saveAttachmentsToServer(key, this._getFileBaseNameFromItem(item),
+					item.attachments, prefs, attachmentCallback);
 			}
-			
-			itemsDoneCallback(items);
-			return items;
-		}.bind(this));
+		}
+		
+		return items;
 	},
 
 	/**
@@ -511,11 +504,10 @@ ItemSaver.prototype = {
 	 * @param {Function} attachmentCallback A callback that receives information about attachment
 	 *     save progress. The callback will be called as attachmentCallback(attachment, false, error)
 	 *     on failure or attachmentCallback(attachment, progressPercent) periodically during saving.
-	 * @returns {Promise} resolves upon all attachments being uploaded or first failure to upload
 	 * @private
 	 */
-	_saveAttachmentsToServer: function(itemKey, baseName, attachments, prefs, attachmentCallback=()=>0) {
-		var promises = [];
+	_saveAttachmentsToServer: async function(itemKey, baseName, attachments, prefs, attachmentCallback=()=>0) {
+		let promises = []
 		for (let attachment of attachments) {
 			let isSnapshot = false;
 			if (attachment.mimeType) {
@@ -530,255 +522,37 @@ ItemSaver.prototype = {
 				// Skip attachment due to prefs
 				continue;
 			}
-			
-			let deferredHeadersProcessed = Zotero.Promise.defer();
-			let itemKeyPromise = deferredHeadersProcessed.promise
-				.then(() => this._createAttachmentItem(itemKey, attachment));
-			let deferredAttachmentData = Zotero.Promise.defer();
-			
-			if (attachment.snapshot === false && attachment.mimeType) {
-				// If we aren't taking a snapshot and we have the MIME type, we don't need
-				// to download any data
-				attachment.linkMode = "linked_url";
-				attachmentCallback && attachmentCallback(attachment, 0);
-				deferredHeadersProcessed.resolve();
-				deferredAttachmentData.resolve();
-			}
-			else {
-				let method = (attachment.snapshot === false ? "HEAD" : "GET");
-				let options = { responseType: (isSnapshot ? "document" : "arraybuffer"), timeout: 60000 };
-				Zotero.HTTP.request(method, attachment.url, options).then((xhr) => {
-					deferredHeadersProcessed.resolve(this._processAttachmentHeaders(attachment, xhr, baseName));
-					deferredAttachmentData.resolve(xhr.response);
-				}, (e) => {
-					deferredHeadersProcessed.reject(e);
-					deferredAttachmentData.reject(e);
-				});
-				if (attachmentCallback) attachmentCallback(attachment, 0);
-			}
-			
-			let promise = Zotero.Promise.all([itemKeyPromise, deferredAttachmentData.promise]).then(function(result) {
-				attachmentCallback(attachment, 50);
-				// Attachment item created on zotero.org, store the key
-				attachment.key = result[0];
-				// Attachment downloaded, store the data
-				attachment.data = result[1];
-				if (attachment.linkMode !== "linked_url") {
-					return this._uploadAttachmentToServer(attachment, attachmentCallback);
-				}
-			}.bind(this)).then(function() {
-				attachmentCallback(attachment, 100);
-			}).catch(function(e) {
-				Zotero.logError(e);
-				attachmentCallback(Object.assign({}, attachment, {parentItem: itemKey}), false, e);
-				throw e;
-			});
-			promises.push(promise);
-		}
-		// This throws if at least one upload fails
-		return Zotero.Promise.all(promises);
-	},
 
-	/**
-	 * Creates an attachment item on the Zotero server. This assigns a "key" to the item
-	 * and allows to upload the attachment data
-	 *
-	 * @param parentItemKey
-	 * @param attachment
-	 * @returns {Promise.<String>} Item key
-	 * @private
-	 */
-	_createAttachmentItem: function(parentItemKey, attachment) {
-		// deproxify url
-		if (this._proxy && attachment.url) {
-			attachment.url = this._proxy.toProper(attachment.url);
-		}
-		var item = [{
-			"itemType":"attachment",
-			"parentItem":parentItemKey,
-			"linkMode":attachment.linkMode,
-			"title":(attachment.title ? attachment.title.toString() : "Untitled Attachment"),
-			"accessDate":"CURRENT_TIMESTAMP",
-			"url":attachment.url,
-			"note":(attachment.note ? attachment.note.toString() : ""),
-			"tags":(attachment.tags && attachment.tags instanceof Array ? attachment.tags : [])
-		}];
-		
-		return Zotero.API.createItem(item).then(function(response) {
-			try {
-				return JSON.parse(response);
-			} catch(e) {
-				throw new Error(`Unexpected response from server ${response}`);
-			}
-		}).then(function(response) {
-			Zotero.debug(`Attachment item created for ${attachment.title}`);
-			return response.success[0];
-		});
-	},
+			attachment.parentKey = itemKey;
 
-	/**
-	 * Performs attachment header processing and throws an error upon failure.
-	 *
-	 * @param {Object} attachment
-	 * @param {XMLHttpRequest} xhr
-	 * @param {String} baseName - attachment base filename on the server
-	 * @private
-	 */
-	_processAttachmentHeaders: function(attachment, xhr, baseName) {
-		// Validate status
-		if (xhr.status === 0 || attachment.snapshot === false) {
-			// Failed due to SOP, or we are supposed to be getting a snapshot
-			attachment.linkMode = "linked_url";
-		} else if (xhr.status !== 200) {
-			throw new Error(`Zotero.org returned unexpected status code ${xhr.status}`);
-		} else {
-			// Validate content type
-			var contentType = "application/octet-stream",
-				charset = null,
-				contentTypeHeader = xhr.getResponseHeader("Content-Type");
-			if (contentTypeHeader) {
-				// See RFC 2616 sec 3.7
-				var m = /^[^\x00-\x1F\x7F()<>@,;:\\"\/\[\]?={} ]+\/[^\x00-\x1F\x7F()<>@,;:\\"\/\[\]?={} ]+/.exec(contentTypeHeader);
-				if(m) contentType = m[0].toLowerCase();
-				m = /;\s*charset\s*=\s*("[^"]+"|[^\x00-\x1F\x7F()<>@,;:\\"\/\[\]?={} ]+)/.exec(contentTypeHeader);
-				if (m) {
-					charset = m[1];
-					if(charset[0] === '"') charset = charset.substring(1, charset.length-1);
-				}
-				
-				if (attachment.mimeType
-					&& attachment.mimeType.toLowerCase() !== contentType.toLowerCase()) {
-					throw new Error("Attachment MIME type "+contentType+
-						" does not match specified type "+attachment.mimeType);
-				}
-			}
-			
-			attachment.mimeType = contentType;
-			attachment.linkMode = "imported_url";
-			switch (contentType.toLowerCase()) {
+			switch (attachment.mimeType.toLowerCase()) {
 			case "application/pdf":
 				attachment.filename = baseName+".pdf";
 				break;
 			case "text/html":
 			case "application/xhtml+xml":
 				attachment.filename = baseName+".html";
+				attachment.data = Zotero.Utilities.Connector.packString(await Zotero.SingleFile.retrievePageData());
 				break;
 			default:
 				attachment.filename = baseName;
 			}
-			if (charset) attachment.charset = charset;
-		}
-	},
 
-	/**
-	 * Uploads an attachment to the Zotero server
-	 * @param {Object} attachment Attachment object, including
-	 * @param {Function} attachmentCallback A callback that receives information about attachment
-	 *     save progress. The callback will be called as attachmentCallback(attachment, false, error)
-	 *     on failure or attachmentCallback(attachment, progressPercent) periodically during saving.
-	 */
-	"_uploadAttachmentToServer":function(attachment, attachmentCallback) {
-		Zotero.debug("Uploading attachment to server");
-		switch(attachment.mimeType.toLowerCase()) {
-			case "text/html":
-			case "application/xhtml+xml":
-				// It's possible that we didn't know if this was a snapshot until after the
-				// download began. If this is the case, we need to convert it to a document.
-				if(attachment.data instanceof ArrayBuffer) {
-					var me = this,
-						blob = new Blob([attachment.data], {"type":attachment.mimeType}),
-						reader = new FileReader();
-					reader.onloadend = function() {
-						if(reader.error) {
-							attachmentCallback(attachment, false, reader.error);
-						} else {
-							// Convert to an HTML document
-							var result = reader.result, doc;
-							try {
-								// First try using DOMParser
-								doc = (new DOMParser()).parseFromString(result, "text/html");
-							} catch(e) {}
-							
-							// If DOMParser fails, use document.implementation.createHTMLDocument,
-							// as documented at https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
-							if(!doc) {
-								doc = document.implementation.createHTMLDocument("");
-								var docEl = doc.documentElement;
-								// AMO reviewer: This code is not run in Firefox, and the document
-								// is never rendered anyway
-								docEl.innerHTML = result;
-								if(docEl.children.length === 1 && docEl.firstElementChild === "html") {
-									doc.replaceChild(docEl.firstElementChild, docEl);
-								}
-							}
-							
-							attachment.data = doc;
-							me._uploadAttachmentToServer(attachment, attachmentCallback);
-						}
-					}
-					reader.readAsText(blob, attachment.charset || "iso-8859-1");
-					return;
-				}
-				
-				// We are now assured that attachment.data is an HTMLDocument, so we can 
-				// add a base tag
-				
-				// Get the head tag
-				var doc = attachment.data,
-					head = doc.getElementsByTagName("head");
-				if(!head.length) {
-					head = doc.createElement("head");
-					var docEl = attachment.data.documentElement;
-					docEl.insertBefore(head, docEl.firstChildElement);
-				} else {
-					head = head[0];
-				}
-				
-				// Add the base tag
-				var base = doc.createElement("base");
-				base.href = attachment.url;
-				head.appendChild(base);
-				
-				// Remove content type tags
-				var metaTags = doc.getElementsByTagName("meta"), metaTag;
-				for(var i=0; i<metaTags.length; i++) {
-					metaTag = metaTags[i];
-					var attr = metaTag.getAttribute("http-equiv");
-					if(attr && attr.toLowerCase() === "content-type") {
-						metaTag.parentNode.removeChild(metaTag);
-					}
-				}
-				
-				// Add UTF-8 content type
-				metaTag = doc.createElement("meta");
-				metaTag.setAttribute("http-equiv", "Content-Type");
-				metaTag.setAttribute("content", attachment.mimeType+"; charset=UTF-8");
-				head.insertBefore(metaTag, head.firstChild);
-				
-				// Serialize document to UTF-8
-				var src = new XMLSerializer().serializeToString(doc),
-					srcLength = Zotero.Utilities.getStringByteLength(src),
-					srcArray = new Uint8Array(srcLength);
-				Zotero.Utilities.stringToUTF8Array(src, srcArray);
-				
-				// Rewrite data
-				attachment.data = srcArray.buffer;
-				attachment.charset = "UTF-8";
-			break;
+			// Don't download attachment if snapshot is specifically set to false
+			attachment.linkMode = attachment.snapshot === false ? "linked_url" : "imported_url";
+
+			try {
+				attachmentCallback(attachment, 0);
+				promises.push(Zotero.ItemSaver.saveAttachmentToServer(attachment));
+				attachmentCallback(attachment, 100);
+			}
+			catch (e) {
+				attachmentCallback(attachment, false, e);
+				Zotero.logError(e);
+				continue;
+			}
 		}
-		
-		var binaryHash = this._md5(new Uint8Array(attachment.data), 0, attachment.data.byteLength),
-			hash = "";
-		for(var i=0; i<binaryHash.length; i++) {
-			if(binaryHash[i] < 16) hash += "0";
-			hash += binaryHash[i].toString(16);
-		}
-		attachment.md5 = hash;
-		
-		ItemSaver._attachmentCallbacks[attachment.id] = function(status, error) {
-			attachmentCallback(attachment, status, error);
-		};
-		Zotero.API.uploadAttachment(attachment);
+		await Promise.all(promises);
 	},
 	
 	/**
@@ -807,135 +581,9 @@ ItemSaver.prototype = {
 			parts.push(item.title.substr(0, 50));
 		}
 		
-		if(parts.length) return parts.join(" - ");
+		if(parts.length) return parts.join(" - ").trim();
 		return "Attachment";
 	},
-	
-	/*
-	  pdf.js MD5 implementation
-	  Copyright (c) 2011 Mozilla Foundation
-
-	  Contributors: Andreas Gal <gal@mozilla.com>
-	                Chris G Jones <cjones@mozilla.com>
-	                Shaon Barman <shaon.barman@gmail.com>
-	                Vivien Nicolas <21@vingtetun.org>
-	                Justin D'Arcangelo <justindarc@gmail.com>
-	                Yury Delendik
-	                Kalervo Kujala
-	                Adil Allawi <@ironymark>
-	                Jakob Miland <saebekassebil@gmail.com>
-	                Artur Adib <aadib@mozilla.com>
-	                Brendan Dahl <bdahl@mozilla.com>
-	                David Quintana <gigaherz@gmail.com>
-
-	  Permission is hereby granted, free of charge, to any person obtaining a
-	  copy of this software and associated documentation files (the "Software"),
-	  to deal in the Software without restriction, including without limitation
-	  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-	  and/or sell copies of the Software, and to permit persons to whom the
-	  Software is furnished to do so, subject to the following conditions:
-
-	  The above copyright notice and this permission notice shall be included in
-	  all copies or substantial portions of the Software.
-
-	  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-	  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-	  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-	  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-	  DEALINGS IN THE SOFTWARE.
-	*/
-	"_md5":(function calculateMD5Closure() {
-		// Don't throw if typed arrays are not supported
-		try {
-			var r = new Uint8Array([
-				7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
-				5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
-				4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
-				6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21]);
-		
-			var k = new Int32Array([
-				-680876936, -389564586, 606105819, -1044525330, -176418897, 1200080426,
-				-1473231341, -45705983, 1770035416, -1958414417, -42063, -1990404162,
-				1804603682, -40341101, -1502002290, 1236535329, -165796510, -1069501632,
-				643717713, -373897302, -701558691, 38016083, -660478335, -405537848,
-				568446438, -1019803690, -187363961, 1163531501, -1444681467, -51403784,
-				1735328473, -1926607734, -378558, -2022574463, 1839030562, -35309556,
-				-1530992060, 1272893353, -155497632, -1094730640, 681279174, -358537222,
-				-722521979, 76029189, -640364487, -421815835, 530742520, -995338651,
-				-198630844, 1126891415, -1416354905, -57434055, 1700485571, -1894986606,
-				-1051523, -2054922799, 1873313359, -30611744, -1560198380, 1309151649,
-				-145523070, -1120210379, 718787259, -343485551]);
-		} catch(e) {};
-	
-		function hash(data, offset, length) {
-			var h0 = 1732584193, h1 = -271733879, h2 = -1732584194, h3 = 271733878;
-			// pre-processing
-			var paddedLength = (length + 72) & ~63; // data + 9 extra bytes
-			var padded = new Uint8Array(paddedLength);
-			var i, j, n;
-			if (offset || length != data.byteLength) {
-				padded.set(new Uint8Array(data.buffer, offset, length));
-			} else {
-				padded.set(data);
-			}
-			i = length;
-			padded[i++] = 0x80;
-			n = paddedLength - 8;
-			while (i < n)
-				padded[i++] = 0;
-			padded[i++] = (length << 3) & 0xFF;
-			padded[i++] = (length >> 5) & 0xFF;
-			padded[i++] = (length >> 13) & 0xFF;
-			padded[i++] = (length >> 21) & 0xFF;
-			padded[i++] = (length >>> 29) & 0xFF;
-			padded[i++] = 0;
-			padded[i++] = 0;
-			padded[i++] = 0;
-			// chunking
-			// TODO ArrayBuffer ?
-			var w = new Int32Array(16);
-			for (i = 0; i < paddedLength;) {
-				for (j = 0; j < 16; ++j, i += 4) {
-					w[j] = (padded[i] | (padded[i + 1] << 8) |
-						   (padded[i + 2] << 16) | (padded[i + 3] << 24));
-				}
-				var a = h0, b = h1, c = h2, d = h3, f, g;
-				for (j = 0; j < 64; ++j) {
-					if (j < 16) {
-						f = (b & c) | ((~b) & d);
-						g = j;
-					} else if (j < 32) {
-						f = (d & b) | ((~d) & c);
-						g = (5 * j + 1) & 15;
-					} else if (j < 48) {
-						f = b ^ c ^ d;
-						g = (3 * j + 5) & 15;
-					} else {
-						f = c ^ (b | (~d));
-						g = (7 * j) & 15;
-					}
-					var tmp = d, rotateArg = (a + f + k[j] + w[g]) | 0, rotate = r[j];
-					d = c;
-					c = b;
-					b = (b + ((rotateArg << rotate) | (rotateArg >>> (32 - rotate)))) | 0;
-					a = tmp;
-				}
-				h0 = (h0 + a) | 0;
-				h1 = (h1 + b) | 0;
-				h2 = (h2 + c) | 0;
-				h3 = (h3 + d) | 0;
-			}
-			return new Uint8Array([
-					h0 & 0xFF, (h0 >> 8) & 0xFF, (h0 >> 16) & 0xFF, (h0 >>> 24) & 0xFF,
-					h1 & 0xFF, (h1 >> 8) & 0xFF, (h1 >> 16) & 0xFF, (h1 >>> 24) & 0xFF,
-					h2 & 0xFF, (h2 >> 8) & 0xFF, (h2 >> 16) & 0xFF, (h2 >>> 24) & 0xFF,
-					h3 & 0xFF, (h3 >> 8) & 0xFF, (h3 >> 16) & 0xFF, (h3 >>> 24) & 0xFF
-			]);
-		}
-		return hash;
-	})()
 };
 
 export default ItemSaver;

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -32,8 +32,8 @@ Zotero.ItemSaver = Zotero.ItemSaver || {};
  * @param attachment
  * @param sessionID 
  */
-Zotero.ItemSaver.saveAttachmentToZotero = async function(attachment, sessionID) {
-	let arrayBuffer = await this._fetchAttachment(attachment);
+Zotero.ItemSaver.saveAttachmentToZotero = async function(attachment, sessionID, tab) {
+	let arrayBuffer = await this._fetchAttachment(attachment, tab);
 	
 	const metadata = {
 		id: attachment.id,
@@ -53,8 +53,8 @@ Zotero.ItemSaver.saveAttachmentToZotero = async function(attachment, sessionID) 
 	}, arrayBuffer);
 }
 
-Zotero.ItemSaver.saveStandaloneAttachmentToZotero = async function(attachment, sessionID) {
-	let arrayBuffer = await this._fetchAttachment(attachment);
+Zotero.ItemSaver.saveStandaloneAttachmentToZotero = async function(attachment, sessionID, tab) {
+	let arrayBuffer = await this._fetchAttachment(attachment, tab);
 
 	const metadata = {
 		url: attachment.url,
@@ -73,14 +73,145 @@ Zotero.ItemSaver.saveStandaloneAttachmentToZotero = async function(attachment, s
 	}, arrayBuffer);
 }
 
-Zotero.ItemSaver._fetchAttachment = async function(attachment) {
+Zotero.ItemSaver._fetchAttachment = async function(attachment, tab, attemptBotProtectionBypass=true) {
 	let options = { responseType: "arraybuffer", timeout: 60000 };
 	let xhr = await Zotero.HTTP.request("GET", attachment.url, options);
 	let { contentType } = Zotero.Utilities.Connector.getContentTypeFromXHR(xhr);
 
-	if (attachment.mimeType.toLowerCase() !== contentType.toLowerCase()) {
+	if (attachment.mimeType.toLowerCase() === contentType.toLowerCase()) {
+		return xhr.response;
+	}
+	
+	// Only attempt fallback for attachments on whitelisted domains
+	if (!tab || !attemptBotProtectionBypass || !this._isIframeBotBypassWhitelistedDomain(attachment.url)) {
 		throw new Error("Attachment MIME type "+contentType+
 			" does not match specified type "+attachment.mimeType);
 	}
-	return xhr.response;
-}
+	
+	let originalUrl = attachment.url;
+	try {
+		let pdfURL = await this._passJSBotDetectionViaHiddenIframe(attachment.url, tab);
+		attachment.url = pdfURL;
+		return await this._fetchAttachment(attachment, false);
+	}
+	catch (e) {
+		Zotero.debug(`Failed to pass JS bot detection via hidden iframe for URL: ${attachment.url}`);
+		Zotero.debug(e);
+		let pdfURL = await this._passJSBotDetectionViaWindowPrompt(originalUrl, tab);
+		attachment.url = pdfURL;
+		return this._fetchAttachment(attachment, false);
+	}
+};
+
+
+Zotero.ItemSaver._passJSBotDetectionViaHiddenIframe = async function(url, tab) {
+	const id = Math.random().toString(36).slice(2, 11);
+	const iframeUrl = Zotero.getExtensionURL("browserAttachmentMonitor/browserAttachmentMonitor.html") + `#url=${encodeURIComponent(url)}`;
+
+	Zotero.debug(`Attempting to pass JS bot detection via hidden iframe for URL: ${url}`);
+
+	// Wait for the monitor frame to load
+	const waitForAttachmentPromise = new Promise((resolve) => {
+		const messageListener = async (message) => {
+			if (message.type === 'attachment-monitor-loaded' 
+				&& !message.success) {
+				Zotero.debug(`Iframe loaded for ${url}`);
+				browser.runtime.onMessage.removeListener(messageListener);
+				// Wait for 5s. Any longer means we've probably hit a Captcha page
+				resolve(Zotero.BrowserAttachmentMonitor.waitForAttachment(tab.id, 5000))
+			}
+		};
+		browser.runtime.onMessage.addListener(messageListener);
+	});
+
+	await browser.scripting.executeScript({
+		target: { tabId: tab.id },
+		func: (url, id) => {
+			return new Promise((resolve) => {
+				let iframe = document.createElement('iframe');
+				iframe.style.display = 'none';
+				iframe.src = url;
+				iframe.id = id;
+
+				iframe.onload = () => {
+					resolve();
+				};
+
+				document.body.appendChild(iframe);
+			});
+		},
+		args: [iframeUrl, id]
+	});
+
+	try {
+		let pdfURL = await waitForAttachmentPromise;
+		Zotero.debug(`Successfully passed JS bot detection for URL: ${url}`);
+		return pdfURL;
+	}
+	finally {
+		await browser.scripting.executeScript({
+			target: { tabId: tab.id },
+			func: (id) => {
+				const iframe = document.getElementById(id);
+				if (iframe) {
+					iframe.parentNode.removeChild(iframe);
+				}
+			},
+			args: [id]
+		});
+	}
+};
+
+Zotero.ItemSaver._passJSBotDetectionViaWindowPrompt = async function(url, tab) {
+	Zotero.debug(`Attempting to pass JS bot detection via window prompt for URL: ${url}`);
+	
+	// Get screen dimensions and position
+	const screenInfo = await browser.scripting.executeScript({
+		target: { tabId: tab.id },
+		func: () => {
+			return {
+				width: window.screen.availWidth,
+				height: window.screen.availHeight,
+				left: window.screen.availLeft,
+				top: window.screen.availTop
+			};
+		}
+	});
+	
+	const screen = screenInfo[0].result;
+	const width = Math.floor(screen.width * 0.8);
+	const height = Math.floor(screen.height * 0.8);
+	const left = screen.left + Math.floor((screen.width - width) / 2);
+	const top = screen.top + Math.floor((screen.height - height) / 2);
+	
+	// Create window for CAPTCHA solving
+	const monitorUrl = Zotero.getExtensionURL("browserAttachmentMonitor/browserAttachmentMonitor.html") + `#url=${encodeURIComponent(url)}`;
+	const window = await browser.windows.create({
+		url: monitorUrl,
+		type: 'popup',
+		width,
+		height,
+		left,
+		top
+	});
+	
+	try {
+		// Wait for successful PDF URL capture
+		const pdfURL = await Zotero.BrowserAttachmentMonitor.waitForAttachment(window.tabs[0].id);
+		Zotero.debug(`Successfully passed JS bot detection for URL: ${url}`);
+		return pdfURL;
+	}
+	finally {
+		// Clean up: close the window
+		await browser.windows.remove(window.id);
+	}
+};
+
+Zotero.ItemSaver._isIframeBotBypassWhitelistedDomain = function(url) {
+	const WHITELISTED_DOMAINS = [
+		'sciencedirect.com',
+	];
+	
+	const hostname = new URL(url).hostname;
+	return WHITELISTED_DOMAINS.some(domain => hostname.endsWith(domain));
+};

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -155,6 +155,16 @@ Zotero.ItemSaver._createServerAttachmentItem = async function(attachment) {
 
 Zotero.ItemSaver._fetchAttachment = async function(attachment, tab, attemptBotProtectionBypass=true) {
 	let options = { responseType: "arraybuffer", timeout: 60000 };
+	if (!Zotero.isSafari) {
+		let cookies = await browser.cookies.getAll({
+			url: attachment.url,
+			partitionKey: {},
+		});
+		options.headers = {
+			"Cookie": cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ')
+		}
+		options.referrer = attachment.referrer;
+	}
 	let xhr = await Zotero.HTTP.request("GET", attachment.url, options);
 	let { contentType } = Zotero.Utilities.Connector.getContentTypeFromXHR(xhr);
 

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -1,0 +1,86 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+    Copyright © 2024 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+Zotero.ItemSaver = Zotero.ItemSaver || {};
+/**
+ * Saves binary attachments to Zotero by fetching them as ArrayBuffer and passing to Zotero.
+ * We do this in the background page, otherwise we would have to pass the ArrayBuffer
+ * between content scripts and background, and it's bad for performance (and also requires
+ * severe workarounds due to brokenness in MV3 https://issues.chromium.org/issues/338162118 )
+ * @param attachment
+ * @param sessionID 
+ */
+Zotero.ItemSaver.saveAttachmentToZotero = async function(attachment, sessionID) {
+	let arrayBuffer = await this._fetchAttachment(attachment);
+	
+	const metadata = {
+		id: attachment.id,
+		url: attachment.url,
+		contentType: attachment.mimeType,
+		parentItemID: attachment.parentItem,
+		title: attachment.title,
+	}
+
+	return Zotero.Connector.callMethod({
+		method: "saveAttachment",
+		headers: {
+			"Content-Type": `${attachment.mimeType}`,
+			"X-Metadata": JSON.stringify(metadata)
+		},
+		queryString: `sessionID=${sessionID}`
+	}, arrayBuffer);
+}
+
+Zotero.ItemSaver.saveStandaloneAttachmentToZotero = async function(attachment, sessionID) {
+	let arrayBuffer = await this._fetchAttachment(attachment);
+
+	const metadata = {
+		url: attachment.url,
+		contentType: attachment.mimeType,
+		title: attachment.title,
+	}
+
+	return Zotero.Connector.callMethod({
+		method: "saveStandaloneAttachment",
+		headers: {
+			"Content-Type": `${attachment.mimeType}`,
+			"X-Metadata": JSON.stringify(metadata)
+		},
+		queryString: `sessionID=${sessionID}`,
+		timeout: 60e3
+	}, arrayBuffer);
+}
+
+Zotero.ItemSaver._fetchAttachment = async function(attachment) {
+	let options = { responseType: "arraybuffer", timeout: 60000 };
+	let xhr = await Zotero.HTTP.request("GET", attachment.url, options);
+	let { contentType } = Zotero.Utilities.Connector.getContentTypeFromXHR(xhr);
+
+	if (attachment.mimeType.toLowerCase() !== contentType.toLowerCase()) {
+		throw new Error("Attachment MIME type "+contentType+
+			" does not match specified type "+attachment.mimeType);
+	}
+	return xhr.response;
+}

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -139,8 +139,8 @@ Zotero.ItemSaver._createServerAttachmentItem = async function(attachment) {
 		url: attachment.url,
 		tags: Array.isArray(attachment.tags) ? attachment.tags : []
 	}];
-	if (attachment.parentItem) {
-		item[0].parentItem = attachment.parentItem;
+	if (attachment.parentKey) {
+		item[0].parentItem = attachment.parentKey;
 	}
 	
 	let response = await Zotero.API.createItem(item);

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -73,6 +73,64 @@ Zotero.ItemSaver.saveStandaloneAttachmentToZotero = async function(attachment, s
 	}, arrayBuffer);
 }
 
+Zotero.ItemSaver.saveAttachmentToServer = async function(attachment, tab) {
+	let promises = []
+	promises.push(this._createServerAttachmentItem(attachment));
+
+	// SingleFile snapshot
+	if (attachment.data) {
+		let snapshotString = await Zotero.Utilities.Connector.unpackString(attachment.data);
+		attachment.data = new Uint8Array(Zotero.Utilities.getStringByteLength(snapshotString));
+		Zotero.Utilities.stringToUTF8Array(snapshotString, attachment.data);
+	}
+	// Don't download if the attachment is supposed to be linked
+	if (!attachment.data || attachment.linkMode !== "imported_url") {
+		promises.push(this._fetchAttachment(attachment, tab));
+	}
+
+	const [itemKey, arrayBuffer] = await Promise.all(promises);
+
+	attachment.data = attachment.data || new Uint8Array(arrayBuffer);
+	// If no data then no need to upload
+	if (!attachment.data) return;
+
+	attachment.key = itemKey;
+	attachment.md5 = this.md5(attachment.data);
+
+	return Zotero.API.uploadAttachment(attachment);
+}
+
+
+/**
+ * Creates an attachment item on the Zotero server. This assigns a "key" to the item
+ * and allows to upload the attachment data
+ *
+ * @param parentItemKey
+ * @param attachment
+ * @returns {Promise.<String>} Item key
+ * @private
+ */
+Zotero.ItemSaver._createServerAttachmentItem = async function(attachment) {
+	var item = [{
+		itemType: "attachment",
+		parentItem: attachment.parentKey,
+		linkMode: attachment.linkMode,
+		title: attachment.title ? attachment.title.toString() : "Untitled Attachment",
+		accessDate: "CURRENT_TIMESTAMP",
+		url: attachment.url,
+		tags: Array.isArray(attachment.tags) ? attachment.tags : []
+	}];
+	
+	let response = await Zotero.API.createItem(item);
+	try {
+		response = JSON.parse(response);
+	} catch(e) {
+		throw new Error(`Unexpected response from server ${response}`);
+	}
+	Zotero.debug(`Attachment item created for ${attachment.title}`);
+	return response.success[0];
+},
+
 Zotero.ItemSaver._fetchAttachment = async function(attachment, tab, attemptBotProtectionBypass=true) {
 	let options = { responseType: "arraybuffer", timeout: 60000 };
 	let xhr = await Zotero.HTTP.request("GET", attachment.url, options);
@@ -215,3 +273,139 @@ Zotero.ItemSaver._isIframeBotBypassWhitelistedDomain = function(url) {
 	const hostname = new URL(url).hostname;
 	return WHITELISTED_DOMAINS.some(domain => hostname.endsWith(domain));
 };
+
+Zotero.ItemSaver.md5 = function(uint8Array) {
+	var binaryHash = this._md5(uint8Array, 0, uint8Array.byteLength),
+		hash = "";
+	for(var i=0; i<binaryHash.length; i++) {
+		if(binaryHash[i] < 16) hash += "0";
+		hash += binaryHash[i].toString(16);
+	}
+	return hash;
+}
+
+/*
+	pdf.js MD5 implementation
+	Copyright (c) 2011 Mozilla Foundation
+
+	Contributors: Andreas Gal <gal@mozilla.com>
+				Chris G Jones <cjones@mozilla.com>
+				Shaon Barman <shaon.barman@gmail.com>
+				Vivien Nicolas <21@vingtetun.org>
+				Justin D'Arcangelo <justindarc@gmail.com>
+				Yury Delendik
+				Kalervo Kujala
+				Adil Allawi <@ironymark>
+				Jakob Miland <saebekassebil@gmail.com>
+				Artur Adib <aadib@mozilla.com>
+				Brendan Dahl <bdahl@mozilla.com>
+				David Quintana <gigaherz@gmail.com>
+
+	Permission is hereby granted, free of charge, to any person obtaining a
+	copy of this software and associated documentation files (the "Software"),
+	to deal in the Software without restriction, including without limitation
+	the rights to use, copy, modify, merge, publish, distribute, sublicense,
+	and/or sell copies of the Software, and to permit persons to whom the
+	Software is furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+	THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+	FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+	DEALINGS IN THE SOFTWARE.
+*/
+Zotero.ItemSaver._md5 = (function calculateMD5Closure() {
+	// Don't throw if typed arrays are not supported
+	try {
+		var r = new Uint8Array([
+			7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+			5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+			4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+			6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21]);
+	
+		var k = new Int32Array([
+			-680876936, -389564586, 606105819, -1044525330, -176418897, 1200080426,
+			-1473231341, -45705983, 1770035416, -1958414417, -42063, -1990404162,
+			1804603682, -40341101, -1502002290, 1236535329, -165796510, -1069501632,
+			643717713, -373897302, -701558691, 38016083, -660478335, -405537848,
+			568446438, -1019803690, -187363961, 1163531501, -1444681467, -51403784,
+			1735328473, -1926607734, -378558, -2022574463, 1839030562, -35309556,
+			-1530992060, 1272893353, -155497632, -1094730640, 681279174, -358537222,
+			-722521979, 76029189, -640364487, -421815835, 530742520, -995338651,
+			-198630844, 1126891415, -1416354905, -57434055, 1700485571, -1894986606,
+			-1051523, -2054922799, 1873313359, -30611744, -1560198380, 1309151649,
+			-145523070, -1120210379, 718787259, -343485551]);
+	} catch(e) {};
+
+	function hash(data, offset, length) {
+		var h0 = 1732584193, h1 = -271733879, h2 = -1732584194, h3 = 271733878;
+		// pre-processing
+		var paddedLength = (length + 72) & ~63; // data + 9 extra bytes
+		var padded = new Uint8Array(paddedLength);
+		var i, j, n;
+		if (offset || length != data.byteLength) {
+			padded.set(new Uint8Array(data.buffer, offset, length));
+		} else {
+			padded.set(data);
+		}
+		i = length;
+		padded[i++] = 0x80;
+		n = paddedLength - 8;
+		while (i < n)
+			padded[i++] = 0;
+		padded[i++] = (length << 3) & 0xFF;
+		padded[i++] = (length >> 5) & 0xFF;
+		padded[i++] = (length >> 13) & 0xFF;
+		padded[i++] = (length >> 21) & 0xFF;
+		padded[i++] = (length >>> 29) & 0xFF;
+		padded[i++] = 0;
+		padded[i++] = 0;
+		padded[i++] = 0;
+		// chunking
+		// TODO ArrayBuffer ?
+		var w = new Int32Array(16);
+		for (i = 0; i < paddedLength;) {
+			for (j = 0; j < 16; ++j, i += 4) {
+				w[j] = (padded[i] | (padded[i + 1] << 8) |
+						(padded[i + 2] << 16) | (padded[i + 3] << 24));
+			}
+			var a = h0, b = h1, c = h2, d = h3, f, g;
+			for (j = 0; j < 64; ++j) {
+				if (j < 16) {
+					f = (b & c) | ((~b) & d);
+					g = j;
+				} else if (j < 32) {
+					f = (d & b) | ((~d) & c);
+					g = (5 * j + 1) & 15;
+				} else if (j < 48) {
+					f = b ^ c ^ d;
+					g = (3 * j + 5) & 15;
+				} else {
+					f = c ^ (b | (~d));
+					g = (7 * j) & 15;
+				}
+				var tmp = d, rotateArg = (a + f + k[j] + w[g]) | 0, rotate = r[j];
+				d = c;
+				c = b;
+				b = (b + ((rotateArg << rotate) | (rotateArg >>> (32 - rotate)))) | 0;
+				a = tmp;
+			}
+			h0 = (h0 + a) | 0;
+			h1 = (h1 + b) | 0;
+			h2 = (h2 + c) | 0;
+			h3 = (h3 + d) | 0;
+		}
+		return new Uint8Array([
+				h0 & 0xFF, (h0 >> 8) & 0xFF, (h0 >> 16) & 0xFF, (h0 >>> 24) & 0xFF,
+				h1 & 0xFF, (h1 >> 8) & 0xFF, (h1 >> 16) & 0xFF, (h1 >>> 24) & 0xFF,
+				h2 & 0xFF, (h2 >> 8) & 0xFF, (h2 >> 16) & 0xFF, (h2 >>> 24) & 0xFF,
+				h3 & 0xFF, (h3 >> 8) & 0xFF, (h3 >> 16) & 0xFF, (h3 >>> 24) & 0xFF
+		]);
+	}
+	return hash;
+})()

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -115,7 +115,9 @@ Zotero.ItemSaver.saveAttachmentToServer = async function(attachment, tab) {
 	attachment.key = itemKey;
 	attachment.md5 = this.md5(attachment.data);
 
-	return Zotero.API.uploadAttachment(attachment);
+	// Do not return here or a message is attempted to pass back to injected page
+	// which causes a failure due to it sometimes exceeding max message length.
+	await Zotero.API.uploadAttachment(attachment);
 }
 
 

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -133,13 +133,15 @@ Zotero.ItemSaver.saveAttachmentToServer = async function(attachment, tab) {
 Zotero.ItemSaver._createServerAttachmentItem = async function(attachment) {
 	var item = [{
 		itemType: "attachment",
-		parentItem: attachment.parentKey,
 		linkMode: attachment.linkMode,
 		title: attachment.title ? attachment.title.toString() : "Untitled Attachment",
 		accessDate: "CURRENT_TIMESTAMP",
 		url: attachment.url,
 		tags: Array.isArray(attachment.tags) ? attachment.tags : []
 	}];
+	if (attachment.parentItem) {
+		item[0].parentItem = attachment.parentItem;
+	}
 	
 	let response = await Zotero.API.createItem(item);
 	try {

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -171,7 +171,8 @@ var MESSAGES = {
 	},
 	ItemSaver: {
 		saveAttachmentToZotero: true,
-		saveStandaloneAttachmentToZotero: true
+		saveStandaloneAttachmentToZotero: true,
+		saveAttachmentToServer: true
 	},
 	Errors: {
 		log: false,

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -169,6 +169,10 @@ var MESSAGES = {
 		get: true,
 		count: true,
 	},
+	ItemSaver: {
+		saveAttachmentToZotero: true,
+		saveStandaloneAttachmentToZotero: true
+	},
 	Errors: {
 		log: false,
 		getErrors: true,

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -309,7 +309,11 @@ if (Zotero.isSafari) {
 // but there's a 64MB limit or Chrome literally crashes
 const MAX_CONTENT_SIZE = 8 * (1024 * 1024);
 function packArrayBuffer(arrayBuffer) {
-	if (!Zotero.isChromium) return arrayBuffer;
+	if (Zotero.isFirefox) return arrayBuffer;
+	if (Zotero.isSafari) {
+		// Base64 encode the arrayBuffer
+		return Zotero.Utilities.arrayBufferToBase64(arrayBuffer);
+	}
 	if (Zotero.isManifestV3) {
 		let array = Array.from(new Uint8Array(arrayBuffer));
 		if (array.length > MAX_CONTENT_SIZE) {
@@ -323,7 +327,10 @@ function packArrayBuffer(arrayBuffer) {
 }
 
 async function unpackArrayBuffer(packedBuffer) {
-	if (!Zotero.isChromium) return packedBuffer;
+	if (Zotero.isFirefox) return packedBuffer;
+	if (Zotero.isSafari) {
+		return Zotero.Utilities.base64ToArrayBuffer(packedBuffer);
+	}
 	if (Zotero.isManifestV3) {
 		return new Uint8Array(packedBuffer).buffer
 	}

--- a/src/common/tools/testTranslators/testTranslators.html
+++ b/src/common/tools/testTranslators/testTranslators.html
@@ -45,7 +45,7 @@
 		<script type="text/javascript" src="/translate/rdf/term.js"></script>
 		<script type="text/javascript" src="/translate/rdf/identity.js"></script>
 		<script type="text/javascript" src="/translate/rdf/rdfparser.js"></script>
-		<script type="text/javascript" src="/translate_item.js"></script>
+		<script type="text/javascript" src="/itemSaver.js"></script>
 		<script type="text/javascript" src="/inject/sandboxManager.js"></script>
 		<script type="text/javascript" src="/utilities/openurl.js"></script>
 		<script type="text/javascript" src="/utilities/xregexp-all.js"></script>

--- a/src/common/translate.js
+++ b/src/common/translate.js
@@ -1,0 +1,43 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2024 Corporation for Digital Scholarship
+					Vienna, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+
+/**
+ * Override to pass itemType to the Connector ItemSaver
+ */
+Zotero.Translate.Web.prototype._prepareTranslation = Zotero.Promise.method(function () {
+	this._itemSaver = new Zotero.Translate.ItemSaver({
+		libraryID: this._libraryID,
+		collections: this._collections,
+		itemType: this._currentTranslator.itemType,
+		attachmentMode: Zotero.Translate.ItemSaver[(this._saveAttachments ? "ATTACHMENT_MODE_DOWNLOAD" : "ATTACHMENT_MODE_IGNORE")],
+		forceTagType: 1,
+		sessionID: this._sessionID,
+		cookieSandbox: this._cookieSandbox,
+		proxy: this._proxy,
+		baseURI: this.location
+	});
+	this.newItems = [];
+});

--- a/src/common/ui/ProgressWindow.jsx
+++ b/src/common/ui/ProgressWindow.jsx
@@ -199,8 +199,9 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		if (!targets) {
 			state.targetSelectorShown = false;
 		}
+		let targetName = target?.name || "zotero.org";
 		// Alert that the item is being saved or has already been saved
-		let alert = this.done ? Zotero.getString("progressWindow_alreadySaved") : `${text} ${target.name}`;
+		let alert = this.done ? Zotero.getString("progressWindow_alreadySaved") : `${text} ${targetName}`;
 		document.getElementById("messageAlert").textContent = alert
 		this.setState(state, () => {
 			this.setFilter();
@@ -667,6 +668,9 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 	}
 	
 	setFilter() {
+		let rows = this.state.targets;
+		if (!rows) return;
+
 		let filter = document.querySelector('.ProgressWindow-filterInput')?.value || "";
 		let crossIcon = document.querySelector(".ProgressWindow-cross");
 		filter = filter.toLowerCase();
@@ -682,7 +686,6 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		}
 		let passingIDs = {};
 		let passingParentIDs = {};
-		let rows = this.state.targets;
 		if (!isFilterEmpty && Object.keys(this.expandedRowsCache).length == 0) {
 			// Just started filtering - remember which rows were expanded
 			for (let row of rows) {

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -80,6 +80,23 @@ Zotero.Utilities.Connector = {
 		}
 	},
 	
+	getContentTypeFromXHR: function(xhr) {
+		var contentType = "application/octet-stream",
+			charset = null,
+			contentTypeHeader = xhr.getResponseHeader("Content-Type");
+		if (contentTypeHeader) {
+			// See RFC 2616 sec 3.7
+			var m = /^[^\x00-\x1F\x7F()<>@,;:\\"\/\[\]?={} ]+\/[^\x00-\x1F\x7F()<>@,;:\\"\/\[\]?={} ]+/.exec(contentTypeHeader);
+			if(m) contentType = m[0].toLowerCase();
+			m = /;\s*charset\s*=\s*("[^"]+"|[^\x00-\x1F\x7F()<>@,;:\\"\/\[\]?={} ]+)/.exec(contentTypeHeader);
+			if (m) {
+				charset = m[1];
+				if(charset[0] === '"') charset = charset.substring(1, charset.length-1);
+			}
+		}
+		return { contentType, charset };
+	},
+	
 	// Chrome has a limit of somewhere between 64 and 128 MB for messages.
 	// There's been an open bug on the chrome bugtracker to fix this since
 	// 2017: https://bugs.chromium.org/p/chromium/issues/detail?id=774158

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -186,6 +186,47 @@ Zotero.Utilities.Connector = {
 			b=ii(b,c,d,a,x[i+ 9],21, -343485551);a=ad(a,olda);b=ad(b,oldb);c=ad(c,oldc);d=ad(d,oldd);
 		}
 		return rh(a)+rh(b)+rh(c)+rh(d);
+	},
+	
+	/**
+	 * Converts an ArrayBuffer to a base64 encoded string
+	 * 
+	 * @param {ArrayBuffer} buffer - The ArrayBuffer to convert
+	 * @return {string} - The base64 encoded string
+	 */
+	arrayBufferToBase64: function(buffer) {
+		// Create a Uint8Array view of the ArrayBuffer
+		const uint8Array = new Uint8Array(buffer);
+		
+		// Convert to a binary string
+		let binary = '';
+		const len = uint8Array.byteLength;
+		for (let i = 0; i < len; i++) {
+			binary += String.fromCharCode(uint8Array[i]);
+		}
+		
+		// Convert binary string to base64
+		return btoa(binary);
+	},
+	
+	/**
+	 * Converts a base64 encoded string back to an ArrayBuffer
+	 * 
+	 * @param {string} base64 - The base64 encoded string to convert
+	 * @return {ArrayBuffer} - The ArrayBuffer
+	 */
+	base64ToArrayBuffer: function(base64) {
+		// Convert base64 to binary string
+		const binaryString = atob(base64);
+		const len = binaryString.length;
+		
+		// Create a Uint8Array from the binary string
+		const uint8Array = new Uint8Array(len);
+		for (let i = 0; i < len; i++) {
+			uint8Array[i] = binaryString.charCodeAt(i);
+		}
+		
+		return uint8Array.buffer;
 	}
 };
 

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -187,7 +187,7 @@ var Zotero = global.Zotero = new function() {
 	this.initGlobal = async function() {
 		await Zotero.Errors.init();
 		if (Zotero.isManifestV3) {
-			Zotero.logError(`Service worker (re)started at ${Zotero.Date.dateToSQL(new Date())}`);
+			Zotero.Errors.logServiceWorkerStarts(Zotero.Date.dateToSQL(new Date()));
 		}
 		Zotero.isBackground = true;
 		

--- a/src/messages.json
+++ b/src/messages.json
@@ -134,13 +134,13 @@
 		"message": "latest version"
 	},
 	"progressWindow_OA_searching": {
-		"message": "Searching for Open Access files…"
+		"message": "Searching for open-access version…"
 	},
 	"progressWindow_OA_notFound": {
-		"message": "No Open Access PDFs found"
+		"message": "No open-access version found"
 	},
 	"progressWindow_OA_failed": {
-		"message": "Failed to get Open Access PDF"
+		"message": "Failed to download open-access version"
 	},
 
 	

--- a/src/messages.json
+++ b/src/messages.json
@@ -136,9 +136,6 @@
 	"progressWindow_OA_searching": {
 		"message": "Searching for open-access version…"
 	},
-	"progressWindow_OA_notFound": {
-		"message": "No open-access version found"
-	},
 	"progressWindow_OA_failed": {
 		"message": "Failed to download open-access version"
 	},

--- a/src/messages.json
+++ b/src/messages.json
@@ -133,6 +133,17 @@
 	"progressWindow_error_upgradeClient_latestVersion": {
 		"message": "latest version"
 	},
+	"progressWindow_OA_searching": {
+		"message": "Searching for Open Access files…"
+	},
+	"progressWindow_OA_notFound": {
+		"message": "No Open Access PDFs found"
+	},
+	"progressWindow_OA_failed": {
+		"message": "Failed to get Open Access PDF"
+	},
+
+	
 	
 	"itemSelector_title": {
 		"message": "Select which items you’d like to add to your library:"

--- a/src/safari/inject_safari.js
+++ b/src/safari/inject_safari.js
@@ -110,10 +110,6 @@ if (isTopWindow) {
 			Zotero.Connector.reportActiveURL(document.location.href);
 		}
 	}, true);
-
-	if (document.hasFocus()) {
-		Zotero.Connector.reportActiveURL(document.location.href);
-	}
 	
 	Zotero.Messaging.addMessageListener('buttonClick', function() {
 		Zotero.Connector_Browser.onPerformCommand();
@@ -122,6 +118,13 @@ if (isTopWindow) {
 	Zotero.Messaging.addMessageListener("selectDone", function(returnItems) {
 		Zotero.Inject._selectCallback(returnItems);
 	});
+
+	if (document.hasFocus()) {
+		(async () => {
+			await Zotero.initDeferred.promise;
+			Zotero.Connector.reportActiveURL(document.location.href);
+		})()
+	}
 }
 
 function onSafariPageLoad() {

--- a/src/safari/messaging_global.js
+++ b/src/safari/messaging_global.js
@@ -43,7 +43,7 @@ Zotero.Messaging.receiveSwiftMessage = async function(messageName, id, data=[], 
 	try {
 		var result = await Zotero.Messaging.receiveMessage(messageName, data, Zotero.Connector_Browser.getTab(tabId));
 	} catch (err) {
-		Zotero.logError(err);
+		// Zotero.logError(err);
 		result = ["error", JSON.stringify(Object.assign({
 			name: err.name,
 			message: err.message,


### PR DESCRIPTION
Changes the Zotero Connector so that attachments (PDF, etc) are downloaded in the connector with a background fetch and passed directly to Zotero. The Zotero Connector is backwards compatible with older Zotero versions which do not support receiving attachments from the Connector (new version of Zotero will not be backwards compatible with old connectors).

Supports advanced captcha handling (under whitelist, currently only sciencedirect.com), where if a PDF fetch fails we will load the pdf in a hidden frame and intercept upon content-disposition: attachment and then refetch with xhr. If hidden iframe fails, we pop open a window for the user to solve the captcha, and once again intercept and refetch with xhr. Seems to work very well. This is not supported on Safari, and we will still want to keep the captcha handling code in Zotero too (for magic wand, etc).

Generally means that attachment saving when access is provided by a proxy will now work in pretty much every case, since we don't need to pass credentials to Zotero and pretend we are the user's browser there.

Also fixed attachment saving to server.

Safari also needs: https://github.com/zotero/safari-app-extension/pull/7
Corresponding Zotero PR: https://github.com/zotero/zotero/pull/5148

Closes https://github.com/zotero/zotero-connectors/issues/474 , closes #414, closes https://github.com/zotero/zotero-connectors/issues/509