### PR TITLE
pass partitioned cookies to desktop

### DIFF
--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -204,7 +204,8 @@ Zotero.Connector = new function() {
 	this.callMethodWithCookies = function(options, data, tab) {
 		if (Zotero.isBrowserExt) {
 			let cookieParams = {
-				url: tab.url
+				url: tab.url,
+				partitionKey: {} // fetch cookies from partitioned and unpartitioned storage
 			};
 			// When first-party isolation is enabled in Firefox, browser.cookies.getAll()
 			// will fail if firstPartyDomain isn't provided, causing all saves to fail. According


### PR DESCRIPTION
Send cookies from partitioned and unpartitioned storage to the desktop client per
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll#partitionkey

This should help with fetching pdfs from sciencedirect.

More context in https://github.com/zotero/zotero/pull/5157#issuecomment-2752442252