### PR TITLE
Add support to remotely enable Google Docs V2 API

### DIFF
--- a/src/common/test/data/googleDocs-integration.html
+++ b/src/common/test/data/googleDocs-integration.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+	<title>Google Docs Integration Test</title>
+</head>
+<body>
+<div id="test-content">
+	<h1>Google Docs Integration Test Page</h1>
+	<p>This page is used to test the Google Docs integration functionality.</p>
+</div>
+<!--SCRIPTS-->
+<script src='../../lib/sinon.js'></script>
+<script src='../../zotero-google-docs-integration/googleDocs.js'></script>
+<script src='../../zotero-google-docs-integration/client.js'></script>
+<script src='../../zotero-google-docs-integration/clientAppsScript.js'></script>
+</body>
+</html> 

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -359,7 +359,8 @@ Zotero.Prefs = new function() {
 		"proxies.loopPreventionTimestamp": 0,
 		
 		"integration.googleDocs.enabled": true,
-		"integration.googleDocs.useGoogleDocsAPI": false,
+		"integration.googleDocs.useV2API": false,
+		"integration.googleDocs.forceDisableV2API": false,
 		
 		"shortcuts.cite": {ctrlKey: true, altKey: true, key: 'c'}
 	};

--- a/src/common/zotero_config.js
+++ b/src/common/zotero_config.js
@@ -26,6 +26,7 @@
 const ZOTERO_CONFIG = {
 	CLIENT_NAME: 'Zotero',
 	DOMAIN_NAME: 'zotero.org',
+	SETTINGS_URL: 'https://repo.zotero.org/settings',
 	REPOSITORY_URL: 'https://repo.zotero.org/repo/',
 	REPOSITORY_CHECK_INTERVAL: 86400, // 24 hours
 	REPOSITORY_RETRY_INTERVAL: 3600, // 1 hour

--- a/test/tests/googleDocsApiTest.mjs
+++ b/test/tests/googleDocsApiTest.mjs
@@ -1,0 +1,68 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2017 Center for History and New Media
+					George Mason University, Fairfax, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+import { background } from '../support/utils.mjs';
+
+describe("Zotero.GoogleDocs.API", function() {
+	describe('#getDocument()', function() {
+		it('Reports 500 errors to repository', async function() {
+			let reportCallArgs = await background(async function() {
+				let authStub, httpStub;
+				let reportCallArgs;
+				try {
+					// Stub auth headers
+					authStub = sinon.stub(Zotero.GoogleDocs.API, 'getAuthHeaders').resolves({'Authorization': 'Bearer test'});
+					
+					// Stub HTTP requests
+					httpStub = sinon.stub(Zotero.HTTP, 'request').callThrough();
+					
+					// First call (to docs.googleapis.com) throws 500 error
+					httpStub.withArgs('GET', 'https://docs.googleapis.com/v1/documents/test-doc-id?includeTabsContent=true').rejects(new Zotero.HTTP.StatusError({status: 500, responseText: 'Internal Server Error'}));
+					// Second call (to zotero.org) returns OK
+					httpStub.withArgs('POST', 'https://repo.zotero.org/repo/report').callsFake((...args) => {
+						reportCallArgs = args;
+					});
+
+					try {
+						await Zotero.GoogleDocs.API.getDocument('test-doc-id');
+					} catch (e) {
+						Zotero.debug(e);
+					}
+					
+					// Return the arguments from the second call
+					return reportCallArgs;
+				}
+				finally {
+					authStub?.restore();
+					httpStub?.restore();
+				}
+			});
+			
+			assert.isArray(reportCallArgs);
+			assert.include(reportCallArgs[1], 'zotero.org');
+			assert.include(reportCallArgs[2].body, 'googleDocsV2APIError');
+		});
+	});
+}); 

--- a/test/tests/googleDocsTest.mjs
+++ b/test/tests/googleDocsTest.mjs
@@ -1,0 +1,157 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2025 Corporation for Digital Scholarship
+					Vienna, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+import { Tab, getExtensionURL, stubHTTPRequest } from '../support/utils.mjs';
+
+describe("Zotero.GoogleDocs", function() {
+	describe('Google Docs V2 selection logic', function() {
+		var tab = new Tab();
+
+		beforeEach(async function() {
+			await tab.init(getExtensionURL('test/data/googleDocs-integration.html'));
+			await tab.run(async () => {
+				await Zotero.initDeferred.promise;
+				sinon.stub(Zotero.Inject, 'loadReactComponents').resolves();
+				Zotero.Connector_Browser = {injectScripts: () => {}};
+				Zotero.GoogleDocs.UI = {init: () => {}};
+			});
+		});
+		
+		afterEach(async function() {
+			await tab.close();
+		});
+
+		it('should use V1 when reportTranslationFailure is false', async function() {
+			const isV2Enabled = await tab.run(async function() {
+				sinon.stub(Zotero.Prefs, 'getAsync').callThrough().withArgs('reportTranslationFailure').resolves(false);
+				
+				await Zotero.GoogleDocs.init();
+				return Zotero.GoogleDocs.Client.isV2;
+			});
+			
+			assert.isNotOk(isV2Enabled);
+		});
+
+		it('should use V1 when integration.googleDocs.forceDisableV2API is true', async function() {
+			const isV2Enabled = await tab.run(async function() {
+				sinon.stub(Zotero.Prefs, 'getAsync').callThrough().withArgs('integration.googleDocs.forceDisableV2API').resolves(true);
+				
+				await Zotero.GoogleDocs.init();
+				return Zotero.GoogleDocs.Client.isV2;
+			});
+			
+			assert.isNotOk(isV2Enabled);
+		});
+
+		describe("when reportTranslationFailure is true", function() {
+			it('should use V2 when server returns true', async function() {
+				let restoreStub;
+				try {
+					// Stub the HTTP request to return true for isGoogleDocsV2Enabled
+					restoreStub = await stubHTTPRequest({ 'repo.zotero.org/settings': { gdocs_version: 2 } });
+
+					const isV2Enabled = await tab.run(async function() {
+						await Zotero.GoogleDocs.init();
+						return Zotero.GoogleDocs.Client.isV2;
+					});
+					
+					assert.isOk(isV2Enabled);
+				} finally {
+					if (restoreStub) await restoreStub();
+				}
+			});
+
+			it('should use V1 when server returns false', async function() {
+				let restoreStub;
+				try {
+					// Stub the HTTP request to return true for isGoogleDocsV2Enabled
+					restoreStub = await stubHTTPRequest({ 'repo.zotero.org/settings': { } });
+
+					const isV2Enabled = await tab.run(async function() {
+						await Zotero.GoogleDocs.init();
+						
+						return Zotero.GoogleDocs.Client.isV2;
+					});
+					
+					assert.isNotOk(isV2Enabled);
+				} finally {
+					if (restoreStub) await restoreStub();
+				}
+			});
+
+			it('should use V1 when server request fails', async function() {
+				const isV2Enabled = await tab.run(async function() {
+					sinon.stub(Zotero.HTTP, 'request').rejects(new Zotero.HTTP.StatusError({status: 500}, 'https://repo.zotero.org/settings'));
+					
+					await Zotero.GoogleDocs.init();
+					return Zotero.GoogleDocs.Client.isV2;
+				});
+				
+				assert.isNotOk(isV2Enabled);
+			});
+		});
+	});
+
+	describe('V2Client', function() {
+		it('should switch to V1 when 500 error is thrown', async function() {
+			var tab = new Tab();
+
+			try {
+				await tab.init(getExtensionURL('test/data/googleDocs-integration.html'));
+				await tab.run(async () => {
+					await Zotero.initDeferred.promise;
+				});
+
+				const result = await tab.run(async function() {
+					let client = new Zotero.GoogleDocs.Client('test-doc-id');
+					
+					sinon.stub(client, 'getDocument').throws(new Error('500: Google Docs request failed'));
+					let prefsSetStub = sinon.stub(Zotero.Prefs, 'set');
+					let initClientStub = sinon.stub(Zotero.GoogleDocs, 'initClient');
+					let clientStub;
+					sinon.stub(Zotero.GoogleDocs, 'ClientAppsScript').callsFake(() => {
+						clientStub = { init: async () => 0, call: sinon.stub() };
+						return clientStub;
+					});
+					
+					await client.call({ command: 'Document.getDocument', arguments: [0] });
+					
+					// Verify the behavior
+					return {
+						prefsSetCalled: prefsSetStub.calledWith('integration.googleDocs.forceDisableV2API', true),
+						initClientCalled: initClientStub.calledWith(true),
+						newClientCallCalled: clientStub.call.called,
+					};
+				});
+				
+				assert.isTrue(result.prefsSetCalled, 'Prefs.set should be called with forceDisableV2API=true');
+				assert.isTrue(result.initClientCalled, 'initClient should be called with true');
+				assert.isTrue(result.newClientCallCalled, 'new client call should be called');
+			} finally {
+				await tab.close();
+			}
+		});
+	});
+}); 


### PR DESCRIPTION
If the user has the `Report broken site translators to zotero.org` checked in Connector Preferences -> Advanced, we check the repo for a setting to enable Google Docs V2 API.

If at any point the Google Docs API responds with 500 ([see issue zotero/zotero-google-docs-integration#65](https://github.com/zotero/zotero-google-docs-integration/issues/65), we switch back to the apps script API for the user, and force disable Google Docs API V2 from being enabled so as not to break other documents, and we also send a report to Zotero repo, so that we can track whether this bug on Google Docs side even exists anymore.