### PR TITLE
Fix snapshot attached to one of many saved items

### DIFF
--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -305,7 +305,8 @@ let PageSaving = {
 		}
 		items = this._processNote(items);
 		this.sessionDetails.items = items;
-		let itemSaver = new ItemSaver({sessionID, baseURI: document.location.href, proxy });
+		let itemType = translators[0].itemType;
+		let itemSaver = new ItemSaver({ sessionID, itemType, baseURI: document.location.href, proxy });
 		this.sessionDetails.itemSaver = itemSaver;
 		return itemSaver.saveItems(items, PageSaving._onAttachmentProgress, onItemsSaved)
 	},


### PR DESCRIPTION
Without this, `ItemSaver._itemType` is not set, which breaks the temp workaround to avoid saving snapshots during multi-item checks (which relies on `this._itemType` == "multiple").

https://github.com/zotero/zotero-connectors/blob/7abdfdcc4dc07ae7e771362a10be6304b494c7dd/src/common/itemSaver.js#L158-L161

Fixes: #567

---

With this, if I save multiple items from https://www.metmuseum.org/art/collection/search?department=3&showOnly=highlights (link form the forums post), I no longer end up having an extra snapshot attached to one of the items. I do get some `attachment.mimeType is undefined` errors which stops proper attachments from being saved. It wasn't mentioned in the forums post though, so I wonder if it's just me?