### PR TITLE
Add support for pushing multiple tabs to zotero

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -666,6 +666,7 @@ Zotero.Connector_Browser = new function() {
 		if (Zotero.isFirefox) {
 			_showPreferencesContextMenuItem();
 		}
+		_showTabContextMenuItem();
 	}
 	
 	// context menu item onclick event not supported in event pages (i.e. MV3),
@@ -905,6 +906,13 @@ Zotero.Connector_Browser = new function() {
 		}
 	}
 
+	function _showTabContextMenuItem() {
+		browser.contextMenus.create({
+			id: "zotero-context-menu-tabs",
+			title: `${Zotero.getString('general_saveTo', 'Zotero')}`,
+			contexts: ['tab']
+		});
+	}
 	function _showPreferencesContextMenuItem() {
 		browser.contextMenus.create({
 			type: "separator",
@@ -1191,6 +1199,16 @@ Zotero.Connector_Browser = new function() {
 		}
 	}
 
+	async function _processTabs(info, tab) {
+		if (info.menuItemId === "zotero-context-menu-tabs") {
+			browser.tabs.query({highlighted: true, currentWindow: true}, async (tabs) => {
+				for (let t of tabs) {
+					await _browserAction(t);
+				}
+			});
+		}
+	}
+
 	browser.action.onClicked.addListener(waitForInit(logListenerErrors(_browserAction)));
 	
 	browser.tabs.onRemoved.addListener(waitForInit(logListenerErrors(_clearInfoForTab)));
@@ -1209,6 +1227,8 @@ Zotero.Connector_Browser = new function() {
 	browser.webNavigation.onCommitted.addListener(waitForInit(logListenerErrors(onNavigation)));
 	browser.webNavigation.onDOMContentLoaded.addListener(waitForInit(logListenerErrors(onDOMContentLoaded)))
 	browser.webNavigation.onHistoryStateUpdated.addListener(waitForInit(logListenerErrors(details => onNavigation(details, true))));
+	
+	browser.contextMenus.onClicked.addListener(waitForInit(logListenerErrors(_processTabs)));
 }
 
 Zotero.initGlobal();

--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -294,6 +294,10 @@ Zotero.Connector_Browser = new function() {
 	this.isIncognito = function(tab) {
 		return tab.incognito;
 	}
+
+	this.isTabFocused = function(tab) {
+		return tab.active;
+	}
 	
 	/**
 	 * Checks whether translation scripts are already injected into a frame and if not - injects

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -563,7 +563,7 @@ let PageSaving = {
 		// popup until we've had a chance to hide it (which happens in the 'select'
 		// callback in progressWindow_inject.js).
 		let delay = translator.itemType == 'multiple' ? 100 : 0;
-		setTimeout(() => {
+		let sendShowMessage = () => {
 			Zotero.Messaging.sendMessage(
 				"progressWindow.show",
 				[
@@ -572,7 +572,16 @@ let PageSaving = {
 					false,
 				]
 			);
-		}, delay)
+		}
+		// If tab is not focused (e.g. when saving multiple), setTimeout with 0 delay actually waits for
+		// a long time, probably due to how non-focused tabs are deprioritized in the event loop and causes
+		// the progress window to not be displayed/updated properly
+		if (delay) {
+			setTimeout(sendShowMessage, delay)
+		}
+		else {
+			sendShowMessage();
+		}
 		
 		try {
 			let translators = this.translators.slice(translatorIndex);

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -175,6 +175,7 @@ var MESSAGES = {
 		injectScripts: true,
 		injectSingleFile: true,
 		isIncognito: true,
+		isTabFocused: true,
 		newerVersionRequiredPrompt: true,
 		openTab: false,
 		openConfigEditor: false,


### PR DESCRIPTION
Add a "Save to Zotero" option to the Tab context menu, such that the connector attempts to save all currently selected tabs to the library in one go, avoiding having to manually click connector on each tab.