### PR TITLE
Add OpenAthens support

### DIFF
--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -280,6 +280,7 @@ var MESSAGES = {
 	},
 	Proxies: {
 		loadPrefs: false,
+		validate: true,
 		save: false,
 		remove: false,
 		toggleRedirectLoopPrevention: false

--- a/src/common/preferences/preferences.css
+++ b/src/common/preferences/preferences.css
@@ -1,5 +1,5 @@
 body {
-	font-family: Lucida Grande, Tahoma, Arial, sans;
+	font-family: Lucida Grande, Tahoma, Arial, sans-serif;
 	font-size: 12px;
 	background-color: #b7bfcb;
 }
@@ -84,10 +84,6 @@ body {
 	margin-bottom: 10px;
 }
 
-.group-content {
-	font-size: 11px;
-}
-
 .group-content div:first-child, .group-content p:first-child {
 	margin: 0;
 }
@@ -98,19 +94,19 @@ body {
 
 label {
 	white-space: nowrap;
-	margin-right: 5px;
-	display: flex;
-	align-items: center;	
+	margin-right: 10px;
+	display: inline-flex;
+	align-items: center;
 }
 
 input {
 	font-size: 1em;
-	max-width: 24em;
-	margin-left: 0.5em;
+	margin: 0 3px 0 0;
+	font-family: Lucida Grande, Tahoma, Arial, sans-serif;
 }
 
-input[type=checkbox] {
-	vertical-align: middle;
+label > input[type=text] {
+	margin-left: 5px;
 }
 
 /** Shamelessly stolen from Firefox **/
@@ -137,8 +133,8 @@ input[type=button][disabled="true"] {
   color: rgb(120,120,120);
 }
 
-input.shortcut-input.invalid{
-	/*color: rgba(255, 0, 0, 0.7);*/
+select[multiple] {
+	overflow: auto;
 }
 
 #google-docs-shortcut {
@@ -148,9 +144,4 @@ input.shortcut-input.invalid{
 
 .Preferences-MIMETypeHandling-hostSelect {
 	width: 18em;
-}
-
-.Preferences-Proxies-proxySelect,
-.Preferences-Proxies-hostSelect {
-	width: 24em;
 }

--- a/src/common/preferences/preferences.html
+++ b/src/common/preferences/preferences.html
@@ -122,7 +122,7 @@
 						</p>
 						<div id="advanced-google-docs-subprefs" style="margin-left: 1em">
 <!--							<label style="margin-top: -7px; margin-bottom: 5px"><input type="checkbox" data-pref="integration.googleDocs.useGoogleDocsAPI"/>Enable Google Docs Integration v2 (NEW)</label>-->
-							<label>Add/Edit Citation Shortcut<span class="shortcut-input" data-pref="shortcuts.cite"></span></label>
+							<label>Add/Edit Citation Shortcut<input is="shortcut-input" type="text" class="shortcut-input" data-pref="shortcuts.cite"></label>
 						</div>
 					</div>
 				</div>
@@ -133,7 +133,7 @@
 					<p>
 						<input type="button" id="advanced-button-config-editor" value="Config Editor"/>
 						<!--BEGIN DEBUG-->
-						<input type="button" style="hidden: true" id="advanced-button-open-test-runner" value="Open Integration Test Runner"/>
+						<input type="button" id="advanced-button-open-test-runner" value="Open Integration Test Runner"/>
 						<!--END DEBUG-->
 					</p>
 				</div>

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -693,7 +693,7 @@ Zotero_Preferences.Components.Proxies = class Proxies extends React.PureComponen
 		}
 		
 		let currentProxy = this.state.currentProxy;
-		var multiHost = currentProxy && currentProxy.toProperScheme.includes('%h') || currentProxy.toProperScheme.includes('%u');
+		var multiHost = currentProxy && currentProxy.toProperScheme?.includes('%h') || currentProxy.toProperScheme?.includes('%u');
 		
 		// If a host exists in the last position and is empty, don't allow adding more
 		let disableRemoveHost = this.state.currentHostIdx == -1;

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -83,12 +83,6 @@ var Zotero_Preferences = {
 			});
 		}
 
-		Zotero.Prefs.loadNamespace('shortcuts').then(function() {
-			let spans = document.querySelectorAll('.shortcut-input[data-pref]');
-			for (let span of spans) {
-				ReactDOM.render(<Zotero_Preferences.Components.ShortcutInput pref={span.dataset.pref} />, span);
-			}
-		});
 
 		Zotero.initDeferred.resolve();
 		Zotero.isInject = true;
@@ -414,7 +408,6 @@ Zotero_Preferences.Components.ProxySettings = class ProxySettings extends React.
 					<div className="group-title">Proxy Settings</div>
 					<div className="group-content">
 						<p>Zotero will transparently redirect requests through saved proxies. See the <a href="https://www.zotero.org/support/connector_preferences#proxies">proxy documentation</a> for more information.</p>
-						<p></p>
 						<Zotero_Preferences.Components.ProxyPreferences onTransparentChange={this.handleTransparentChange}/>
 					</div>
 				</div>
@@ -490,13 +483,14 @@ Zotero_Preferences.Components.ProxyPreferences = class ProxyPreferences extends 
 					<label><input type="checkbox" name="transparent" onChange={this.handleCheckboxChange} defaultChecked={this.state.transparent}/>&nbsp;Enable proxy redirection</label>
 					<div style={{marginLeft: "1em"}}>
 						<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="showRedirectNotification" defaultChecked={this.state.showRedirectNotification}/>&nbsp;Show a notification when redirecting through a proxy</label>
+						<br/>
 						{autoRecognise}
 						<p>
-							<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="disableByDomain" defaultChecked={this.state.disableByDomain}/>&nbsp;Disable proxy redirection when my domain name contains<span>*</span></label>
+							<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="disableByDomain" defaultChecked={this.state.disableByDomain}/>&nbsp;Disable proxy redirection when my domain name contains (available when Zotero is running)</label>
+							<br/>
 							<input style={{marginTop: "0.5em", marginLeft: "1.5em"}} type="text" onChange={this.handleTextInputChange} disabled={!this.state.transparent || !this.state.disableByDomain} name="disableByDomainString" defaultValue={this.state.disableByDomainString}/>
 						</p>
 					</div>
-					<p><span>*</span>Available when Zotero is running</p>
 				</div>
 			</div>
 		);
@@ -504,265 +498,241 @@ Zotero_Preferences.Components.ProxyPreferences = class ProxyPreferences extends 
 };
 
 
-Zotero_Preferences.Components.Proxies = class Proxies extends React.PureComponent {
-	constructor(props) {
-		super(props);
-		let proxies = Zotero.Prefs.get('proxies.proxies').map((proxy) => {
-			proxy.toProperScheme = proxy.toProperScheme || proxy.scheme
-			return proxy;
-		});
-		this.state = {
-			proxies,
-			currentProxy: undefined,
-			currentHostIdx: -1
-		};
-		
-		this.handleProxySelectChange = this.handleProxySelectChange.bind(this);
-		this.handleProxyButtonClick = this.handleProxyButtonClick.bind(this);
-		this.handleSchemeChange = this.handleSchemeChange.bind(this);
-		this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
-		this.handleHostSelectChange = this.handleHostSelectChange.bind(this);
-		this.handleHostButtonClick = this.handleHostButtonClick.bind(this);
-		this.handleHostnameChange = this.handleHostnameChange.bind(this);
+Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
+	const { transparent, proxy, onProxyChange } = props;
+
+	if (!transparent || !proxy) {
+		return "";
 	}
-	
-	componentWillMount() {
-		this.saveProxy = Zotero.Utilities.debounce(Zotero.Proxies.save.bind(Zotero.Proxies), 200);
-	}
-	
-	componentDidUpdate(prevProps, prevState) {
-		if (this.focusToProxyInput) {
-			this.focusToProxyInput = false;
-			this.refs.toProxyInput.focus();
-		}
-		else if (this.focusHostInput) {
-			this.focusHostInput = false;
-			this.refs.hostInput.focus();
-		}
-	}
-	
-	/**
-	 * Update the current proxy with a new one and resave it
-	 *
-	 * A lot of this code could be cleaner if state flowed down from the prefs.
-	 */
-	updateCurrentProxyInState(proxy, prevState, newState) {
-		newState.currentProxy = proxy;
-		newState.proxies = prevState.proxies.map((p, i) => p.id == proxy.id ? proxy : p);
-		this.saveProxy(proxy);
-	}
-	
-	handleProxySelectChange(event) {
-		var target = event.target;
-		this.setState((prevState) => {
-			return {
-				currentProxy: prevState.proxies.find(p => target && p.id == target.value),
-				currentHostIdx: -1
+
+	const [toProxyScheme, setToProxyScheme] = React.useState(proxy.toProxyScheme);
+	const [toProperScheme, setToProperScheme] = React.useState(proxy.toProperScheme);
+	const [hosts, setHosts] = React.useState(proxy.hosts);
+	const [currentHostIdx, setCurrentHostIdx] = React.useState(-1);
+	const [autoAssociate, setAutoAssociate] = React.useState(proxy.autoAssociate);
+	const [isOpenAthens, setIsOpenAthens] = React.useState(proxy.type === 'openathens');
+	const [error, setError] = React.useState(null);
+
+	const hostInputRef = React.useRef(null);
+	const toProxyInputRef = React.useRef(null);
+
+	React.useEffect(() => {
+		setToProxyScheme(proxy.toProxyScheme);
+		setToProperScheme(proxy.toProperScheme);
+		setHosts(proxy.hosts);
+		setCurrentHostIdx(-1);
+		setAutoAssociate(proxy.autoAssociate);
+		setIsOpenAthens(proxy.type === 'openathens');
+	}, [proxy?.id]);
+
+	React.useLayoutEffect(() => {
+		// Focus the toProxyScheme input if proxy is new
+		toProxyScheme.includes('example.com') && toProxyInputRef.current?.focus();
+	}, [toProxyScheme])
+
+	React.useLayoutEffect(() => {
+		// Focus the host input if host is new
+		hosts[currentHostIdx]?.length === 0 && hostInputRef.current?.focus();
+	}, [currentHostIdx])
+
+	React.useEffect(() => {
+		(async () => {
+			let updatedProxy = Object.assign(
+				{},
+				proxy,
+				{
+					toProxyScheme: toProxyScheme,
+					toProperScheme: toProperScheme,
+					hosts: hosts.filter(h => h.length),
+					autoAssociate: autoAssociate
+				}
+			);
+			if (isOpenAthens) {
+				updatedProxy.type = 'openathens';
+			} else {
+				delete updatedProxy.type;
 			}
-		});
-	}
-	
-	handleProxyButtonClick(event) {
-		var value = event.target.value;
-		this.setState((prevState) => {
-			var newState = {};
-			// Add proxy
-			if (value == '+') {
-				let newProxy = {
-					id: Date.now(),
-					toProxyScheme: 'https://www.example.com/login?qurl=%u',
-					toProperScheme: '%h.example.com/%p',
-					autoAssociate: true,
-					hosts: []
-				};
-				newState.proxies = prevState.proxies.concat([newProxy]);
-				newState.currentProxy = newProxy;
-				newState.currentHostIdx = -1;
-				this.focusToProxyInput = true;
-				this.saveProxy(newProxy);
+			let error = await Zotero.Proxies.validate(updatedProxy);
+			if (error?.[0] === "proxy_validate_schemeUnmodified") return;
+
+			setError(error);
+			if (error?.[0] === "proxy_validate_hostProxyExists") {
+				updatedProxy.hosts = updatedProxy.hosts.filter(h => h != error[1]);
 			}
-			// Delete proxy
-			else if (value == '-') {
-				let oldProxies = prevState.proxies;
-				let pos = oldProxies.findIndex(p => p == prevState.currentProxy);
-				newState.proxies = [
-					...oldProxies.slice(0, pos),
-					...oldProxies.slice(pos + 1)
-				];
-				Zotero.Proxies.remove(prevState.currentProxy);
-				newState.currentProxy = newState.proxies [pos] || newState.proxies[pos - 1];
-			}
-			return newState;
-		});
-	}
-	
-	handleSchemeChange(event) {
+			else if (error) return;
+
+			saveProxy(updatedProxy);
+			onProxyChange(updatedProxy);
+		})();
+	}, [toProxyScheme, toProperScheme, hosts, autoAssociate, isOpenAthens])
+
+	var multiHost = toProperScheme?.includes('%h') || toProxyScheme?.includes('%u');
+
+	const saveProxy = React.useRef(
+		Zotero.Utilities.debounce(Zotero.Proxies.save.bind(Zotero.Proxies), 200)
+	).current;
+
+	let disableRemoveHost = currentHostIdx == -1;
+
+	function handleSchemeChange(event) {
 		var value = event.target.value;
 		var name = event.target.name;
-		this.setState((prevState) => {
-			var newState = {};
-			var oldProxy = prevState.currentProxy;
-			var newProxy = Object.assign(
-				{},
-				oldProxy,
-				{
-					[name]: value,
-					hosts: [...oldProxy.hosts]
-				}
-			);
-			this.updateCurrentProxyInState(newProxy, prevState, newState);
-			return newState;
-		});
-	}
-	
-	handleCheckboxChange(event) {
-		var target = event.target;
-		this.setState((prevState) => {
-			var newState = {};
-			var oldProxy = prevState.currentProxy;
-			var newProxy = Object.assign(
-				{},
-				oldProxy,
-				{
-					[target.name]: target.checked
-				}
-			);
-			this.updateCurrentProxyInState(newProxy, prevState, newState);
-			return newState;
-		});
-	}
-	
-	handleHostSelectChange(event) {
-		this.setState({
-			currentHostIdx: event.target.value !== "" ? parseInt(event.target.value) : -1
-		});
-	}
-	
-	handleHostButtonClick(event) {
-		var value = event.target.value;
-		this.setState((prevState) => {
-			var newState = {};
-			var oldProxy = prevState.currentProxy;
-			var newProxy = Object.assign({}, oldProxy);
-			// Add host to end
-			if (value == '+') {
-				let lastHostEmpty = oldProxy.hosts.length && oldProxy.hosts[oldProxy.hosts.length-1].trim().length == 0;
-				if (!lastHostEmpty) {
-					newProxy.hosts = oldProxy.hosts.concat(['']);
-				}
-				newState.currentHostIdx = newProxy.hosts.length - 1;
-				this.focusHostInput = true;
-			}
-			// Delete host at current index
-			else if (value == '-') {
-				newProxy.hosts = [
-					...oldProxy.hosts.slice(0, prevState.currentHostIdx),
-					...oldProxy.hosts.slice(prevState.currentHostIdx + 1)
-				];
-				// If this was the last host, select the previous one
-				if (prevState.currentHostIdx == newProxy.hosts.length) {
-					newState.currentHostIdx = prevState.currentHostIdx - 1;
-				}
-			}
-			this.updateCurrentProxyInState(newProxy, prevState, newState);
-			return newState;
-		});
-	}
-	
-	handleHostnameChange(event) {
-		var value = event.target.value;
-		this.setState((prevState) => {
-			var newState = {};
-			var oldProxy = prevState.currentProxy;
-			var newProxy = Object.assign(
-				{},
-				oldProxy,
-				{
-					// Replace the current host value
-					hosts: oldProxy.hosts.map((h, i) => i == prevState.currentHostIdx ? value : h)
-				}
-			);
-			this.updateCurrentProxyInState(newProxy, prevState, newState);
-			return newState;
-		});
-	}
-	
-	renderProxySettings() {
-		if (!this.props.transparent || !this.state.currentProxy) {
-			return "";
+		if (name == 'toProxyScheme') {
+			setToProxyScheme(value);
 		}
+		else if (name == 'toProperScheme') {
+			setToProperScheme(value);
+		}
+	}
+
+	function handleCheckboxChange(event) {
+		var target = event.target;
+		setAutoAssociate(target.checked);
 		
-		let currentProxy = this.state.currentProxy;
-		var multiHost = currentProxy && currentProxy.toProperScheme?.includes('%h') || currentProxy.toProperScheme?.includes('%u');
-		
-		// If a host exists in the last position and is empty, don't allow adding more
-		let disableRemoveHost = this.state.currentHostIdx == -1;
-		
-		return (
-			<div className="group" style={{marginTop: "10px"}}>
-				<p style={{display: "flex", alignItems: "center", flexWrap: "wrap"}}>
-					<label style={{visibility: multiHost ? null : 'hidden'}}><input type="checkbox" name="autoAssociate" onChange={this.handleCheckboxChange} checked={currentProxy.autoAssociate}/>&nbsp;Automatically associate new hosts</label>
-				</p>
-				<p style={{display: "flex", alignItems: "center"}}>
-					<label style={{alignSelf: "center", marginRight: "5px"}}>Login URL Scheme: </label>
-					<input style={{flexGrow: "1"}} type="text" name="toProxyScheme" onChange={this.handleSchemeChange} value={currentProxy.toProxyScheme || ""} ref={"toProxyInput"}/>
-				</p>	
-				<p style={{display: "flex", alignItems: "center"}}>
-					<label style={{alignSelf: "center", marginRight: "5px"}}>Proxied URL Scheme: </label>
-					<input style={{flexGrow: "1"}} type="text" name="toProperScheme" onChange={this.handleSchemeChange} value={currentProxy.toProperScheme} ref={"toProperInput"}/>
-				</p>
+	}
+
+	function handleTypeChange(event) {
+		var value = event.target.value;
+		setIsOpenAthens(value === 'openathens');
+	}
+
+	function handleHostSelectChange(event) {
+		setCurrentHostIdx(event.target.value !== "" ? parseInt(event.target.value) : -1);
+	}
+
+	function handleAddHost() {
+		setHosts(hosts.concat(['']));
+		setCurrentHostIdx(hosts.length);
+	}
+
+	function handleRemoveHost() {
+		setHosts(hosts.filter((h, i) => i != currentHostIdx));
+		if (hosts.length - 1) {
+			setCurrentHostIdx(Math.max(0, currentHostIdx - 1));
+		}
+		else {
+			setCurrentHostIdx(-1);
+		}
+	}
+
+	function handleHostnameChange(event) {
+		var value = event.target.value;
+		setHosts(hosts.map((h, i) => i == currentHostIdx ? value : h));
+	}
+
+	return (
+		<div className="group" style={{marginTop: "10px"}}>
+			<p>
+				<label><input type="radio" name="proxyType" value="ezproxy" checked={!isOpenAthens} onChange={handleTypeChange}/>EZProxy</label>
+				<label><input type="radio" name="proxyType" value="openathens" checked={isOpenAthens} onChange={handleTypeChange}/>OpenAthens</label>
+			</p>
+			<p>
+				<label style={{visibility: multiHost ? null : 'hidden'}}><input type="checkbox" name="autoAssociate" onChange={handleCheckboxChange} checked={autoAssociate}/>&nbsp;Automatically associate new hosts</label>
+			</p>
+			<p>
+				<label>Login URL Scheme:
+					<input style={{flexGrow: "1"}} type="text" name="toProxyScheme" onChange={handleSchemeChange} value={toProxyScheme || ""} ref={toProxyInputRef}/>
+				</label>
+			</p>
+			<p>
+				<label>Proxied URL Scheme:
+					<input style={{flexGrow: "1"}} type="text" name="toProperScheme" onChange={handleSchemeChange} value={toProperScheme || ""}/>
+				</label>
+			</p>
+
+			{error && <p style={{color: "red"}}>{Zotero.getString(error[0], error.slice(1))}</p>}
+
+			<p>
+				You may use the following variables in your proxy schemes:<br/>
+				&#37;h - The hostname of the proxied site (e.g., www.example.com)<br/>
+				&#37;p - The path of the proxied page excluding the leading slash (e.g., about/index.html)<br/>
+				&#37;u - Full encoded proxied site url (e.g. https://www.example.com/about/index.html)
+			</p>
+			
+			<div style={{display: "flex", flexDirection: "column", marginTop: "10px"}}>
+				<label>Hostnames</label>
+				<select className="Preferences-Proxies-hostSelect" size="8" multiple
+						value={[currentHostIdx != -1 ? currentHostIdx : '']}
+						onChange={handleHostSelectChange}>
+					{hosts.map((host, i) =>
+						<option key={i} value={i}>{host}</option>)}
+				</select>
 				<p>
-					You may use the following variables in your proxy schemes:<br/>
-					&#37;h - The hostname of the proxied site (e.g., www.example.com)<br/>
-					&#37;p - The path of the proxied page excluding the leading slash (e.g., about/index.html)<br/>
-					&#37;u - Full encoded proxied site url (e.g. https://www.example.com/about/index.html)
+					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleAddHost} value="+"/>
+					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleRemoveHost} disabled={disableRemoveHost} value="-"/>
 				</p>
 				
-				<div style={{display: "flex", flexDirection: "column", marginTop: "10px"}}>
-					<label>Hostnames</label>
-					<select className="Preferences-Proxies-hostSelect" size="8" multiple
-							value={[this.state.currentHostIdx]}
-							onChange={this.handleHostSelectChange}>
-						{currentProxy.hosts.map((host, i) =>
-							<option key={i} value={i}>{host}</option>)}
-					</select>
-					<p>
-						<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={this.handleHostButtonClick} value="+"/>
-						<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={this.handleHostButtonClick} disabled={disableRemoveHost} value="-"/>
-					</p>
-
-					<p style={{display: this.state.currentHostIdx === -1 ? 'none' : 'flex'}}>
-						<label style={{alignSelf: 'center', marginRight: "5px"}}>Hostname: </label>
+				<p style={{display: currentHostIdx === -1 ? 'none' : 'flex'}}>
+					<label>Hostname:
 						<input style={{flexGrow: '1'}}
 							type="text"
-							value={currentProxy.hosts[this.state.currentHostIdx] || ''}
-							onChange={this.handleHostnameChange} ref={"hostInput"}/>
-					</p>
-				</div>
-			</div>
-		);
-	};
-	
-	render() {
-		return (
-			<div style={{display: "flex", flexDirection: "column"}}>
-				<select className="Preferences-Proxies-proxySelect" size="8" multiple
-						value={[this.state.currentProxy ? this.state.currentProxy.id : '']}
-						onChange={this.handleProxySelectChange}
-						disabled={!this.props.transparent}>
-					{this.state.proxies.length && this.state.proxies.map((proxy, i) => {
-						return <option key={i} value={proxy.id}>{proxy.toProxyScheme || proxy.toProperScheme}</option>;
-					})}
-				</select>
-				<p style={{display: this.props.transparent ? null : 'none'}}>
-					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={this.handleProxyButtonClick} value="+"/>
-					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={this.handleProxyButtonClick} disabled={!this.state.currentProxy} value="-"/>
+							value={hosts[currentHostIdx] || ""}
+							onChange={handleHostnameChange} ref={hostInputRef}/>
+					</label>
 				</p>
-				
-				{this.renderProxySettings()}
 			</div>
-		);
+		</div>
+	);
+};
+
+
+Zotero_Preferences.Components.Proxies = function Proxies(props) {
+	const [proxies, setProxies] = React.useState(() =>
+		Zotero.Prefs.get('proxies.proxies').map((proxy) => {
+			proxy.toProperScheme = proxy.toProperScheme || proxy.scheme;
+			return proxy;
+		})
+	);
+	const [currentProxyIdx, setCurrentProxyIdx] = React.useState(-1);
+
+	function onProxyChange(updatedProxy) {
+		setProxies((prev) => prev.map((p, i) => i == currentProxyIdx ? updatedProxy : p));
 	}
+
+	function handleProxySelectChange(event) {
+		var target = event.target;
+		setCurrentProxyIdx(proxies.findIndex(p => p.id == target.value));
+	}
+
+	function handleProxyAdd() {
+		setProxies((prev) => prev.concat([{
+			id: Date.now(),
+			toProxyScheme: 'https://www.example.com/login?qurl=%u',
+			toProperScheme: '%h.example.com/%p',
+			autoAssociate: true,
+			hosts: []
+		}]));
+		setCurrentProxyIdx(proxies.length);
+	}
+
+	function handleProxyRemove() {
+		setProxies((prev) => prev.filter((p, i) => i != currentProxyIdx));
+		setCurrentProxyIdx(Math.max(0, currentProxyIdx - 1));
+		Zotero.Proxies.remove(proxies[currentProxyIdx]);
+	}
+
+	return (
+		<div style={{display: "flex", flexDirection: "column"}}>
+			<select className="Preferences-Proxies-proxySelect" size="8" multiple
+					value={[currentProxyIdx != -1 ? proxies[currentProxyIdx].id : '']}
+					onChange={handleProxySelectChange}
+					disabled={!props.transparent}>
+				{proxies.length && proxies.map((proxy, i) => {
+					return <option key={i} value={proxy.id}>{proxy.toProxyScheme || proxy.toProperScheme}</option>;
+				})}
+			</select>
+			<p style={{display: props.transparent ? null : 'none'}}>
+				<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleProxyAdd} value="+"/>
+				<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleProxyRemove} disabled={!currentProxyIdx} value="-"/>
+			</p>
+			
+			<Zotero_Preferences.Components.ProxyDetails
+				transparent={props.transparent}
+				proxy={proxies[currentProxyIdx]}
+				onProxyChange={onProxyChange}
+			/>
+		</div>
+	);
 };
 
 
@@ -865,22 +835,49 @@ Zotero_Preferences.Components.MIMETypeHandling = class MIMETypeHandling extends 
 	}
 };
 
-Zotero_Preferences.Components.ShortcutInput = class extends React.Component {
-	constructor(props) {
-		super(props);
-		this.handleKeyDown = this.handleKeyDown.bind(this);
-		this.handleBlur = this.handleBlur.bind(this);
-		this.state = {modifiers: Zotero.Prefs.get(props.pref) || {}};
+
+
+// Customized built-in web component: <input is="shortcut-input">
+class ShortcutInput extends HTMLInputElement {
+	constructor() {
+		super();
+		this._connected = false;
+		this._keys = ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'];
 	}
 
-	async handleKeyDown(e) {
-		if (e.key == 'Tab') {
-			return;
-		}
-		const keys = ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'];
+	async connectedCallback() {
+		if (this._connected) return;
+		this._connected = true;
+		this.setAttribute('autocomplete', 'off');
+		this.setAttribute('spellcheck', 'false');
+		this.addEventListener('keydown', this._handleKeyDown);
+		this.addEventListener('blur', this._handleBlur);
+		await Zotero.initDeferred.promise;
+		await this._updateFromPref();
+	}
+
+	disconnectedCallback() {
+		this.removeEventListener('keydown', this._handleKeyDown);
+		this.removeEventListener('blur', this._handleBlur);
+		this._connected = false;
+	}
+
+	get _prefName() {
+		return this.dataset.pref;
+	}
+
+	async _updateFromPref() {
+		let modifiers = await Zotero.Prefs.getAsync(this._prefName) || {};
+		this.value = Zotero.Utilities.Connector.kbEventToShortcutString(modifiers);
+		this.classList.remove('invalid');
+	}
+
+	_handleKeyDown = async (e) => {
+		if (e.key == 'Tab') return;
+		e.preventDefault();
 		let modifiers = {};
 		let invalid = false;
-		for (let key of keys) {
+		for (let key of this._keys) {
 			modifiers[key] = e[key];
 		}
 		if (e.key.length == 1) {
@@ -888,37 +885,34 @@ Zotero_Preferences.Components.ShortcutInput = class extends React.Component {
 		} else {
 			modifiers.key = '';
 		}
-		if (modifiers.key && keys.some(k => modifiers[k])) {
-			Zotero.Prefs.set(this.props.pref, modifiers);
+		if (e.key == 'Backspace' || e.key == 'Escape' || e.key == 'Delete') {
+			Zotero.Prefs.clear(this._prefName);
+			await this._updateFromPref();
+			return;
+		}
+		if (modifiers.key && this._keys.some(k => modifiers[k])) {
+			Zotero.Prefs.set(this._prefName, modifiers);
 		} else {
 			invalid = true;
 		}
-		if (e.key == 'Backspace' || e.key == 'Escape' || e.key == 'Delete') {
-			Zotero.Prefs.clear(this.props.pref);
-			modifiers = await Zotero.Prefs.getAsync(this.props.pref) || {};
-			invalid = false;
-		}
-		this.setState({modifiers, invalid});
-	}
-
-	async handleBlur() {
-		const keys = ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'];
-		if (!this.state.modifiers.key || !keys.some(k => this.state.modifiers[k])) {
-			let modifiers = await Zotero.Prefs.getAsync(this.props.pref) || {};
-			this.setState({modifiers, invalid: false});
+		this.value = Zotero.Utilities.Connector.kbEventToShortcutString(modifiers);
+		if (invalid) {
+			this.classList.add('invalid');
+		} else {
+			this.classList.remove('invalid');
 		}
 	}
 
-	render() {
-		let val = Zotero.Utilities.Connector.kbEventToShortcutString(this.state.modifiers);
-
-		let classes = "shortcut-input";
-		if (this.state.invalid) {
-			classes += " invalid"
+	_handleBlur = async () => {
+		let saved = await Zotero.Prefs.getAsync(this._prefName) || {};
+		if (!saved.key || !this._keys.some(k => saved[k])) {
+			await this._updateFromPref();
 		}
-
-		return <input className={classes} onKeyDown={this.handleKeyDown} onBlur={this.handleBlur} value={val}/>
 	}
 }
+
+try {
+	customElements.define('shortcut-input', ShortcutInput, { extends: 'input' });
+} catch (e) {}
 
 window.addEventListener("load", Zotero_Preferences.init, false);

--- a/src/common/proxy.js
+++ b/src/common/proxy.js
@@ -39,6 +39,8 @@
 
 "use strict";
 
+const OPENATHENS_REDIRECT_INTERVAL = 12 * 60 * 60 * 1000;
+
 /**
  * A singleton to handle URL rewriting proxies
  * @namespace
@@ -50,17 +52,21 @@ Zotero.Proxies = new function() {
 	this.REDIRECT_LOOP_TIMEOUT = 3600e3;
 	this.REDIRECT_LOOP_MONITOR_COUNT = 4;
 	this.REDIRECT_LOOP_MONITOR_TIMEOUT = 5e3;
+	this.openAthensHostRedirectTime = {};
 	/**
 	 * Initializes the proxy settings
 	 * @returns Promise{boolean} proxy enabled/disabled status
 	 */
-	this.init = function() {
+	this.init = async function() {
 		if (Zotero.isSafari) return;
 		this.transparent = false;
 		this.proxies = [];
 		this.hosts = {};
 		this._redirectedTabIDs = {};
 		this._loopPreventionTimestamp = Zotero.Prefs.get('proxies.loopPreventionTimestamp');
+
+		this.openAthensHostRedirectTime =
+			await Zotero.Utilities.Connector.createMV3PersistentObject('openAthensRedirectTime');
 		
 		this.loadPrefs();
 		
@@ -68,7 +74,7 @@ Zotero.Proxies = new function() {
 		Zotero.Proxies.disabledByDomain = false;
 		
 		Zotero.Proxies.proxies = Zotero.Prefs.get('proxies.proxies').map(function(proxy) {
-			proxy = new Zotero.Proxy(proxy);
+			proxy = Zotero.Proxies._createProxyInstance(proxy);
 			for (let host of proxy.hosts) {
 				Zotero.Proxies.hosts[host] = proxy;
 			}
@@ -100,7 +106,8 @@ Zotero.Proxies = new function() {
 	this.enable = function() {
 		if (Zotero.isBrowserExt) {
 			Zotero.WebRequestIntercept.addListener('headersReceived', Zotero.Proxies.onHeadersReceived);
-			browser.webNavigation.onCommitted.addListener(Zotero.Proxies.onNavigationCommited)
+			browser.webNavigation.onBeforeNavigate.addListener(Zotero.Proxies.onBeforeNavigate)
+			browser.webNavigation.onCommitted.addListener(Zotero.Proxies.checkForRedirectLoop)
 		} else {
 			safari.application.addEventListener('beforeNavigate', this.onBeforeNavigateSafari, false);
 		}
@@ -110,7 +117,8 @@ Zotero.Proxies = new function() {
 	this.disable = function() {
 		if (Zotero.isBrowserExt) {
 			Zotero.WebRequestIntercept.removeListener('headersReceived', Zotero.Proxies.onHeadersReceived);
-			browser.webNavigation.onCommitted.removeListener(Zotero.Proxies.onNavigationCommited)
+			browser.webNavigation.onBeforeNavigate.removeListener(Zotero.Proxies.onBeforeNavigate)
+			browser.webNavigation.onCommitted.removeListener(Zotero.Proxies.checkForRedirectLoop)
 		} else {
 			safari.application.removeEventListener('beforeNavigate', this.onBeforeNavigateSafari, false);
 		}
@@ -155,7 +163,7 @@ Zotero.Proxies = new function() {
 					existingProxy.hosts = Array.from(new Set(existingProxy.hosts));
 				} else {
 					// Otherwise add the proxy
-					Zotero.Proxies.save(new Zotero.Proxy(proxy));
+					Zotero.Proxies.save(Zotero.Proxies._createProxyInstance(proxy));
 				}
 			}
 
@@ -178,7 +186,13 @@ Zotero.Proxies = new function() {
 
 		Zotero.Proxies.updateDisabledByDomain();
 		if (Zotero.Proxies.disabledByDomain) return;
-		let redirect = Zotero.Proxies._maybeRedirect(details);
+		let redirect;
+		for (let proxy of Zotero.Proxies.proxies) {
+			if (typeof proxy.maybeRedirect === 'function') {
+				redirect = proxy.maybeRedirect(details);
+				if (redirect) break;
+			}
+		}
 		if (redirect) {
 			e.target.url = redirect.redirectUrl;
 		}
@@ -190,8 +204,12 @@ Zotero.Proxies = new function() {
 	 */
 	this.onPageLoadSafari = function(tab) {
 		let details = {url: tab.url, type: 'main_frame', tabId: tab, statusCode: 200};
-	
-		Zotero.Proxies._maybeAddHost(details);
+		
+		for (let proxy of Zotero.Proxies.proxies) {
+			if (typeof proxy.maybeAddHost === 'function') {
+				proxy.maybeAddHost(details);
+			}
+		}
 	};
 
 	/**
@@ -214,30 +232,40 @@ Zotero.Proxies = new function() {
 	 *
 	 * @param {Object} details - webRequest details object
 	 */
-	this.onNavigationCommited = (details) => {
+	this.onBeforeNavigate = (details) => {
 		if (details.statusCode >= 400 || details.frameId != 0) {
 			return;
 		}
 
-		Zotero.Proxies._checkForRedirectLoop(details);
-		
-		Zotero.Proxies._maybeAddHost(details);
-
 		Zotero.Proxies.updateDisabledByDomain();
 		if (Zotero.Proxies.disabledByDomain) return;
 		
+		for (let proxy of Zotero.Proxies.proxies) {
+			proxy.maybeAddHost(details);
+		}
+		
 		if (Zotero.Proxies.isPreventingRedirectLoops()) return;
 		
-		let redirect = Zotero.Proxies._maybeRedirect(details);
-		if (redirect) {
-			// We will track this tab in case it causes a redirect loop
+		let redirect;
+		let redirectProxy;
+		for (redirectProxy of Zotero.Proxies.proxies) {
+			if (typeof redirectProxy.maybeRedirect === 'function') {
+				redirect = redirectProxy.maybeRedirect(details);
+				if (redirect) break;
+			}
+		}
+		if (!redirect) return;
+		// We will track this tab in case it causes a redirect loop
+		if (redirectProxy.type !== 'openathens') {
+			// OpenAthens always redirects back to original host, but that's handled by
+			// proxy logic
 			this._redirectedTabIDs[details.tabId] = {
 				host: new URL(details.url).host,
 				count: this.REDIRECT_LOOP_MONITOR_COUNT,
 				timeout: Date.now() + this.REDIRECT_LOOP_MONITOR_TIMEOUT
 			};
-			browser.tabs.update(details.tabId, {url: redirect.redirectUrl});
 		}
+		browser.tabs.update(details.tabId, {url: redirect.redirectUrl});
 	};
 	
 	this.toggleRedirectLoopPrevention = function(value) {
@@ -253,11 +281,11 @@ Zotero.Proxies = new function() {
 		return this._loopPreventionTimestamp > Date.now();
 	}
 	
-	this._checkForRedirectLoop = (details) => {
+	this.checkForRedirectLoop = (details) => {
 		if (details.frameId != 0) return;
 		let redirectedTab = this._redirectedTabIDs[details.tabId];
 		if (redirectedTab) {
-			if (details?.transitionQualifiers.includes('forward_back') || details?.transitionQualifiers.includes('from_address_bar') ) {
+			if (details.transitionQualifiers?.includes('forward_back') || details.transitionQualifiers?.includes('from_address_bar') ) {
 				// History navigation (back button) may cause false-positives here, so we stop monitoring
 				delete this._redirectedTabIDs[details.tabId];
 			}
@@ -275,79 +303,11 @@ Zotero.Proxies = new function() {
 		return false;
 	}
 	
-	this._maybeAddHost = function(details) {
-		// see if there is a proxy we already know
-		var m = false;
-		for (var proxy of Zotero.Proxies.proxies) {
-			if (proxy.regexp) {
-				m = proxy.regexp.exec(details.url);
-				if (m) break;
-			}
-		}
-		if (!m) return;
-		
-		let host = m[proxy.parameters.indexOf("%h")+1];
-		// Unhyphenate host before checking it
-		//
-		// DEBUG: If a site has a valid hyphen in it, we probably won't redirect it properly,
-		// because we'll add the host with a dot instead and won't match it when the original
-		// unproxied site is loaded with the hyphen.
-		if (!host.includes('.')) {
-			host = host.replace(/-/g, '.');
-		}
-		
-		let shouldRemapHostToMatchedProxy = false;
-		let associatedProxy = Zotero.Proxies.hosts[host];
-		if (associatedProxy && associatedProxy.toProperScheme.substr(0, 5) != 'https') {
-			let secureAssociatedProxyScheme = associatedProxy.toProperScheme.substr(0, 4) + 's' + associatedProxy.toProperScheme.substr(4);
-			// I.e. if we matched a proxy with a scheme like https://%h.proxy.edu/%p
-			// (which means that we navigated to https://%h/%p) and the host was previously associated with a
-			// proxy with a scheme like http://%h.proxy.edu/%p, we remap this host to be mapped to the
-			// https proxy instead
-			shouldRemapHostToMatchedProxy = secureAssociatedProxyScheme == proxy.toProperScheme
-		}
-		// add this host if we know a proxy
-		if (proxy.autoAssociate							// if autoAssociate is on
-			&& (!Zotero.Proxies.hosts[host] || shouldRemapHostToMatchedProxy)		// and host is not saved
-			&& proxy.hosts.indexOf(host) === -1
-			&& !Zotero.Proxies._isBlacklisted(host)					// and host is not blacklisted
-		) {
-			if (shouldRemapHostToMatchedProxy) {
-				associatedProxy.hosts = associatedProxy.hosts.filter(h => h != host);
-				Zotero.Proxies.save(associatedProxy);
-			}
-			proxy.hosts.push(host);
-			Zotero.Proxies.save(proxy);
-			Zotero.Proxies.toggleRedirectLoopPrevention(false);
-
-			_showNotification(
-				'New Zotero Proxy Host',
-				`Zotero automatically associated ${host} with a previously defined proxy. Future requests to this site will be redirected through ${proxy.toDisplayName()}.`,
-				["✕", "Proxy Settings", "Don’t Proxy This Site"],
-				details.tabId
-			)
-			.then(function(response) {
-				if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
-				if (response == 2) {
-
-					proxy.hosts = proxy.hosts.filter((h) => h != host);
-					Zotero.Proxies.save(proxy);
-					return browser.tabs.update(details.tabId, {url: proxy.toProper(details.url)})
-				}
-			});
-		}	
-	};
-	
 	this.notifyNewProxy = async function(proxy, tabId) {
-		// If empty or default scheme
-		var invalid = Zotero.Proxies.validate(proxy);
-		if (invalid) {
-			Zotero.debug(`Proxy  ${proxy.toProperScheme} : ${proxy.toProxyScheme} invalid with reason ${JSON.stringify(invalid)}`);
-			return Zotero.Proxies.remove(proxy);
-		}
-		let response = await _showNotification(
+		let instance = Zotero.Proxies._createProxyInstance(proxy);
+		let response = await Zotero.Proxies.showNotification(
 			'New Zotero Proxy',
-			`Zotero detected that you are accessing ${proxy.hosts[proxy.hosts.length-1]} through a proxy. Would you like to automatically redirect future requests to ${proxy.hosts[proxy.hosts.length-1]} through ${proxy.toDisplayName()}?`,
+			`Zotero detected that you are accessing ${proxy.hosts[proxy.hosts.length-1]} through a proxy. Would you like to automatically redirect future requests to ${proxy.hosts[proxy.hosts.length-1]} through ${instance.toDisplayName()}?`,
 			['✕', 'Proxy Settings', 'Accept'],
 			tabId
 		);
@@ -356,10 +316,10 @@ Zotero.Proxies = new function() {
 				title: 'Only add proxies linked from your library, school, or corporate website',
 				message: 'Adding other proxies allows malicious sites to masquerade as sites you trust.<br/></br>'
 				+ 'Adding this proxy will allow Zotero to recognize items from proxied pages and will automatically '
-				+ `redirect future requests to ${proxy.hosts[proxy.hosts.length - 1]} through ${proxy.toDisplayName()}.`,
+				+ `redirect future requests to ${proxy.hosts[proxy.hosts.length - 1]} through ${instance.toDisplayName()}.`,
 				button1Text: 'Add Proxy',
 				button2Text: 'Cancel'
-			});
+			}, tabId);
 			if (result.button == 1) {
 				return Zotero.Proxies.save(proxy);
 			}
@@ -390,143 +350,60 @@ Zotero.Proxies = new function() {
 				let requestURI = new URL(details.url);
 				Zotero.debug("Proxies: Detected "+detectorName+" proxy "+proxy.toProperScheme+" for "+requestURI.host);
 				
-				this.notifyNewProxy(proxy, details.tabId);
+				let invalid = (typeof proxy.validate === 'function') ? proxy.validate() : false;
+				if (invalid) continue;
+
+				this.notifyNewProxy(proxy.toJSON ? proxy.toJSON() : proxy, details.tabId);
 				
 				break;
 			}
 		});
 	};
 
-	this._maybeRedirect = function(details) {
-		var proxied = Zotero.Proxies.properToProxy(details.url, true);
-		if (!proxied
-			// Don't redirect https websites via http proxies
-			|| details.url.substr(0, 5) == 'https' && proxied.substr(0, 5) != 'https') return;
-		
-		var proxiedURI = new URL(proxied);
-		
-		// parse the original request's URL so that we can extract host, etc.
-		let uri = new URL(details.url);
-
-		// make sure that the top two domains (e.g. gmu.edu in foo.bar.gmu.edu) of the
-		// channel and the site to which we're redirecting don't match, to prevent loops.
-		const top2DomainsRe = /[^\.]+\.[^\.]+$/;
-		let top21 = top2DomainsRe.exec(uri.hostname);
-		let top22 = top2DomainsRe.exec(proxiedURI.hostname);
-		if (!top21 || !top22 || top21[0] == top22[0]) {
-			Zotero.debug("Proxies: skipping redirect; redirect URI and URI have same top 2 domains");
-			return;
-		}
-
-		// Otherwise, redirect.
-		if (Zotero.Proxies.showRedirectNotification && details.type === 'main_frame') {
-			let proxy = Zotero.Proxies.hosts[uri.host];
-			_showNotification(
-				'Zotero Proxy Redirection',
-				`Zotero automatically redirected your request to ${uri.host} through the proxy at ${proxy.toDisplayName()}.`,
-				['✕', 'Proxy Settings', "Don’t Proxy This Site"],
-				details.tabId
-			).then(function(response) {
-				if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
-				if (response == 2) {
-					proxy.hosts = proxy.hosts.filter((h) => h != uri.host);
-					Zotero.Proxies.save(proxy);
-					// Don't redirect for hosts associated with frames
-					return browser.tabs.update(details.tabId, {url: details.url})
-				}
-			});
-		}
-
-		return {redirectUrl: proxied};
-	}
 
 
 	/**
 	 * Update proxy and host maps and store proxy settings in storage
 	 */
 	this.save = function(proxy) {
-		proxy.toProxyScheme = (proxy.toProxyScheme || "").trim();
-		proxy.toProperScheme = (proxy.toProperScheme || proxy.scheme || "").trim();
-		proxy.hosts = proxy.hosts.map(host => host.trim()).filter(host => host);
-		
-		// If empty or default scheme
-		var invalid = Zotero.Proxies.validate(proxy);
-		if (invalid) {
-			Zotero.debug(`Proxy  ${proxy.toProperScheme} : ${proxy.toProxyScheme} invalid with reason ${JSON.stringify(invalid)}`);
-			return Zotero.Proxies.remove(proxy);
-		}
+		let instance = Zotero.Proxies._createProxyInstance(proxy);
+
+		instance.toProxyScheme = (instance.toProxyScheme || "").trim();
+		instance.toProperScheme = (instance.toProperScheme || instance.scheme || "").trim();
+		instance.hosts = instance.hosts.map(host => host.trim()).filter(host => host);
 		
 		// If no %h or %u present, then only a single host can be supported and we drop all but the first one.
-		let multiHost = proxy.toProperScheme.includes('%h') || proxy.toProperScheme.includes('%u');
+		// OpenAthens proxies always support multiple hosts via the redirector.
+		let multiHost = (instance.type === 'openathens')
+			|| (instance.toProperScheme || '').includes('%h')
+			|| (instance.toProxyScheme || '').includes('%u');
 		if (!multiHost) {
-			proxy.hosts = proxy.hosts.slice(0, 1);
+			instance.hosts = instance.hosts.slice(0, 1);
 		}
-		proxy = new Zotero.Proxy(proxy);
-	
-		var existingProxyIndex = Zotero.Proxies.proxies.findIndex((p) => p.id == proxy.id);
+		
+		var existingProxyIndex = Zotero.Proxies.proxies.findIndex((p) => p.id == instance.id);
 		if (existingProxyIndex == -1) {
-			Zotero.Proxies.proxies.push(proxy);
+			Zotero.Proxies.proxies.push(instance);
 		}
 		else {
-			Zotero.Proxies.proxies[existingProxyIndex] = proxy;
+			Zotero.Proxies.proxies[existingProxyIndex] = instance;
 		}
-		if (!proxy.regexp) proxy.compileRegexp();
+		if (!instance.regexp && typeof instance.compileRegexp === 'function') instance.compileRegexp();
 
 		// delete hosts that point to this proxy if they no longer exist
 		for (let host in Zotero.Proxies.hosts) {
-			if (Zotero.Proxies.hosts[host].id == proxy.id && proxy.hosts.indexOf(host) == -1) {
+			if (Zotero.Proxies.hosts[host].id == instance.id && instance.hosts.indexOf(host) == -1) {
 				delete Zotero.Proxies.hosts[host];
 			}
 		}
 		
-		for (let host of proxy.hosts) {
-			Zotero.Proxies.hosts[host] = proxy;
+		for (let host of instance.hosts) {
+			Zotero.Proxies.hosts[host] = instance;
 		}
+
+		Object.assign(proxy, instance.toJSON())
 		
 		Zotero.Proxies.storeProxies();
-	};
-
-	/**
-	 * Ensures that the proxy scheme and host settings are valid for this proxy type
-	 *
-	 * @returns {Array{String}|Boolean} An error type if a validation error occurred, or "false" if there was
-	 *	no error.
-	 */
-	this.validate = function(proxy) {
-		if (
-			// Scheme very short
-			proxy.toProperScheme.length <= "%h.-.--/%p".length 
-				// Unmodified
-				|| proxy.toProperScheme == '%h.example.com/%p'
-				|| proxy.toProxyScheme == 'proxy.example.com/login?qurl=%s'
-				// Host is at the end of the domain part of the scheme
-				|| proxy.toProperScheme.includes('%h/')
-				// No-op proxy schemes that don't actually proxy anything (see #492)
-				|| proxy.toProperScheme == '%h/%p'
-				|| proxy.toProperScheme == '%h%p'
-		) {
-			return ["scheme.invalid"];
-		}
-		
-		for (let p of Zotero.Proxies.proxies) {
-			if ((proxy.toProxyScheme == p.toProxyScheme || proxy.toProperScheme == p.toProperScheme) && p.id != proxy.id) {
-				return ["scheme.alreadyExists"]
-			}
-		}
-		
-		if (!Zotero_Proxy_schemeParameterRegexps["%p"].test(proxy.toProperScheme)) {
-			return ["scheme.noPath"];
-		}
-		
-		for (let host in proxy.hosts) {
-			host = host.trim();
-			var oldProxy = Zotero.Proxies.hosts[host];
-			if (oldProxy && oldProxy.proxyID  != proxy.proxyID) {
-				return ["host.proxyExists", host];
-			}
-		}
-		
-		return false;
 	};
 	
 	this.remove = function(proxy) {
@@ -546,14 +423,24 @@ Zotero.Proxies = new function() {
 		let proxies = Zotero.Proxies.proxies.map(function(p) {
 			return {
 				id: p.id,
+				name: p.name,
 				autoAssociate: p.autoAssociate,
 				toProxyScheme: p.toProxyScheme,
 				toProperScheme: p.toProperScheme || p.scheme,
 				hosts: p.hosts,
+				type: p.type
 			};
 		});
 		
 		Zotero.Prefs.set('proxies.proxies', proxies);
+	};
+
+	// Create an instance of the correct proxy subtype
+	this._createProxyInstance = function(json={}) {
+		if (json.type === 'openathens') {
+			return new Zotero.Proxy.OpenAthensProxy(json);
+		}
+		return new Zotero.Proxy(json);
 	};
 
 	/**
@@ -658,7 +545,7 @@ Zotero.Proxies = new function() {
 						var proxyHost = parts.slice(j+1).join('.');
 						let scheme = `%h${skippedParts}.${proxyHost}/%p`
 						// Backwards compatibility
-						urlToProxy[properURL] = {toProperScheme: scheme, scheme, dotsToHyphens: true};
+						urlToProxy[properURL] = {toProperScheme: scheme, scheme};
 					}
 				}
 			}
@@ -720,53 +607,19 @@ Zotero.Proxies = new function() {
 	 * @param {Number} tabId
 	 * @param {Number} timeout
 	 */
-	function _showNotification(title, message, actions, tabId, timeout) {
+	this.showNotification = function(title, message, actions, tabId, timeout) {
 		// browser.notifications.create({
 		// 	type: 'basic',
 		// 	title,
 		// 	message,
 		// 	iconUrl: 'Icon-128.png'
 		// });
-		Zotero.debug(`NOTIFICATION: ${message}`);
+		Zotero.debug(`Proxy notification: ${message}`);
 		actions = actions && actions.map((a) => {return {title: a, dismiss: true}});
 		return Zotero.Connector_Browser.notify(message, actions, timeout, tabId);
 	}
 
 };
-
-/**
- * Creates a Zotero.Proxy object from a DB row
- *
- * @constructor
- * @class A model for a http proxy server
- */
-Zotero.Proxy = function (json={}) {
-	this.id = json.id || Date.now();
-	this.autoAssociate = json.autoAssociate == undefined ? true : !!json.autoAssociate;
-	this.toProperScheme = json.toProperScheme || json.scheme;
-	// Proxy login URL with %u where the URL to-be-proxied should be inserted
-	this.toProxyScheme = json.toProxyScheme;
-	// MV3 proxy toJSON needs this
-	this.scheme = this.toProperScheme;
-	this.hosts = json.hosts || [];
-	this.dotsToHyphens = true;
-	if (this.toProperScheme) {
-		// Loading from storage or new
-		this.compileRegexp();
-	}
-};
-
-/**
- * Convert the proxy to JSON compatible object
- * @returns {Object}
- */
-Zotero.Proxy.prototype.toJSON = function() {
-	if (!this.toProperScheme) {
-		throw Error('Cannot convert proxy to JSON - no scheme');
-	}
-	return {id: this.id, dotsToHyphens: true, scheme: this.toProperScheme, toProperScheme: this.toProperScheme, toProxy: this.toProxyScheme};
-};
-
 
 /**
  * Regexps to match the URL contents corresponding to proxy scheme parameters
@@ -790,148 +643,410 @@ const Zotero_Proxy_schemeParameterRegexps = {
 
 
 /**
- * Compiles the regular expression against which we match URLs to determine if this proxy is in use
- * and saves it in this.regexp
- */
-Zotero.Proxy.prototype.compileRegexp = function() {
-	var indices = this.indices = {};
-	this.parameters = [];
-	for (var param in Zotero_Proxy_schemeParameters) {
-		var index = this.toProperScheme.indexOf(param);
-
-		// avoid escaped matches
-		while (this.toProperScheme[index-1] && (this.toProperScheme[index-1] == "%")) {
-			this.toProperScheme = this.toProperScheme.substr(0, index-1)+this.toProperScheme.substr(index);
-			index = this.toProperScheme.indexOf(param, index+1);
-		}
-
-		if (index != -1) {
-			this.indices[param] = index;
-			this.parameters.push(param);
-		}
-	}
-
-	// sort params by index
-	this.parameters = this.parameters.sort(function(a, b) {
-		return indices[a]-indices[b];
-	});
-
-	// now replace with regexp fragment in reverse order
-	var re;
-	if (this.toProperScheme.includes('://')) {
-		re = "^"+Zotero.Utilities.quotemeta(this.toProperScheme)+"$";
-	} else {
-		re = "^https?"+Zotero.Utilities.quotemeta('://'+this.toProperScheme)+"$";
-	}
-	for(var i=this.parameters.length-1; i>=0; i--) {
-		var param = this.parameters[i];
-		re = re.replace(Zotero_Proxy_schemeParameterRegexps[param], "$1"+Zotero_Proxy_schemeParameters[param]);
-	}
-
-	this.regexp = new RegExp(re);
-}
-
-/**
- * Converts a proxied URL to an unproxied URL using this proxy
+ * Creates a Zotero.Proxy object from a DB row
  *
- * @param m {Array} The match from running this proxy's regexp against a URL spec
- * @type String
+ * @constructor
+ * @class A model for a http proxy server
  */
-Zotero.Proxy.prototype.toProper = function(m) {
-	if (!Array.isArray(m)) {
-		// make sure url has a trailing slash
-		m = new URL(m).href;
-		let match = this.regexp.exec(m);
-		if (!match) {
-			return m
+Zotero.Proxy = class {
+	constructor(json={}) {
+		this.id = json.id || Date.now();
+		// Whether hosts should be automatically associated with this proxy
+		this.autoAssociate = json.autoAssociate !== false;
+		this.name = json.name;
+		this.toProperScheme = json.toProperScheme || json.scheme;
+		// Proxy login URL with %u where the URL to-be-proxied should be inserted
+		this.toProxyScheme = json.toProxyScheme;
+		// MV3 proxy toJSON needs this
+		this.scheme = this.toProperScheme;
+		this.hosts = json.hosts || [];
+		if (this.toProperScheme) {
+			this.compileRegexp();
+		}
+	}
+
+	validate() {
+		for (let host in this.hosts) {
+			host = host.trim();
+			var oldProxy = Zotero.Proxies.hosts[host];
+			if (oldProxy && oldProxy.id != this.id) {
+				return ["host.proxyExists", host];
+			}
+		}
+
+		if (this.toProxyScheme) {
+			let scheme = this.toProxyScheme.trim();
+			for (let p of Zotero.Proxies.proxies) {
+				if (!p || p.id == this.id) continue;
+				if ((p.toProxyScheme || '').trim() && (p.toProxyScheme || '').trim() == scheme) {
+					return ["scheme.duplicate"];
+				}
+			}
+		}
+		
+		if (!this.toProperScheme) return false;
+
+		if (
+			// Scheme very short
+			this.toProperScheme.length <= "%h.-.--/%p".length 
+				// Unmodified
+				|| this.toProperScheme == '%h.example.com/%p'
+				|| this.toProxyScheme == 'proxy.example.com/login?qurl=%s'
+				// Host is at the end of the domain part of the scheme
+				|| this.toProperScheme.includes('%h/')
+				// No-op proxy schemes that don't actually proxy anything (see #492)
+				|| this.toProperScheme == '%h/%p'
+				|| this.toProperScheme == '%h%p'
+		) {
+			return ["scheme.invalid"];
+		}
+
+		if (!Zotero_Proxy_schemeParameterRegexps["%p"].test(this.toProperScheme)) {
+			return ["scheme.noPath"];
+		}
+		return false;
+	}
+
+	/**
+	 * Compiles the regular expression against which we match URLs to determine if this proxy is in use
+	 * and saves it in this.regexp
+	 */
+	compileRegexp() {
+		var indices = this.indices = {};
+		this.parameters = [];
+		for (var param in Zotero_Proxy_schemeParameters) {
+			var index = this.toProperScheme.indexOf(param);
+
+			// avoid escaped matches
+			while (this.toProperScheme[index-1] && (this.toProperScheme[index-1] == "%")) {
+				this.toProperScheme = this.toProperScheme.substr(0, index-1)+this.toProperScheme.substr(index);
+				index = this.toProperScheme.indexOf(param, index+1);
+			}
+
+			if (index != -1) {
+				this.indices[param] = index;
+				this.parameters.push(param);
+			}
+		}
+
+		// sort params by index
+		this.parameters = this.parameters.sort(function(a, b) {
+			return indices[a]-indices[b];
+		});
+
+		// now replace with regexp fragment in reverse order
+		var re;
+		if (this.toProperScheme.includes('://')) {
+			re = "^"+Zotero.Utilities.quotemeta(this.toProperScheme)+"$";
 		} else {
-			m = match;
+			re = "^https?"+Zotero.Utilities.quotemeta('://'+this.toProperScheme)+"$";
 		}
-	}
-	let hostIdx = this.parameters.indexOf("%h");
-	let protocol = m[0].indexOf('https') == 0 ? 'https://' : 'http://';
-	if (hostIdx != -1) {
-		var properURL = protocol+m[hostIdx+1]+"/";
-	} else {
-		var properURL = protocol+this.hosts[0]+"/";
-	}
-	
-	// Replace `-` with `.` in https to support EZProxy HttpsHyphens.
-	// Potentially troublesome with domains that contain dashes
-	if (protocol == "https://" ||
-		!properURL.includes('.')) {
-		properURL = properURL.replace(/-/g, '.');
-	}
-
-	if (this.indices["%p"]) {
-		properURL += m[this.parameters.indexOf("%p")+1];
-	} else {
-		var dir = m[this.parameters.indexOf("%d")+1];
-		var file = m[this.parameters.indexOf("%f")+1];
-		if (dir !== "") properURL += dir+"/";
-		properURL += file;
-	}
-
-	return properURL;
-}
-
-/**
- * Converts an unproxied URL to a proxied URL using this proxy
- *
- * @param {Object|String} uri The URI corresponding to the unproxied URL
- * @type String
- */
-Zotero.Proxy.prototype.toProxy = function(uri) {
-	if (typeof uri == "string") {
-		uri = new URL(uri);
-		// If there's no path it is set to null, but we need
-		// at least an empty string to avoid doing many checks
-		uri.pathname = uri.pathname || '';
-	}
-	if (this.regexp.exec(uri.href) || Zotero.Proxies._isBlacklisted(uri.hostname)) {
-		return uri.href;
-	}
-	if (this.toProxyScheme) {
-		return this.toProxyScheme.replace('%u', encodeURIComponent(uri.href));
-	}
-	var proxyURL = this.toProperScheme;
-
-	for(var i=this.parameters.length-1; i>=0; i--) {
-		var param = this.parameters[i];
-		var value = "";
-		if (param == "%h") {
-			value = (uri.protocol == 'https:') ? uri.hostname.replace(/\./g, '-') : uri.hostname;
-		} else if (param == "%p") {
-			value = uri.pathname.substr(1) + uri.search;
+		for(var i=this.parameters.length-1; i>=0; i--) {
+			var param = this.parameters[i];
+			re = re.replace(Zotero_Proxy_schemeParameterRegexps[param], "$1"+Zotero_Proxy_schemeParameters[param]);
 		}
 
-		proxyURL = proxyURL.substr(0, this.indices[param])+value+proxyURL.substr(this.indices[param]+2);
+		this.regexp = new RegExp(re);
 	}
 
-	if (proxyURL.includes('://')) {
-		return proxyURL;
+
+	/**
+	 * Convert the proxy to JSON compatible object
+	 * @returns {Object}
+	 */
+	toJSON() {
+		return {
+			id: this.id,
+			name: this.name,
+			autoAssociate: this.autoAssociate,
+			toProxyScheme: this.toProxyScheme,
+			toProperScheme: this.toProperScheme,
+			hosts: this.hosts,
+			type: this.type,
+		}
 	}
-	return uri.protocol + '//' + proxyURL;
+
+	/**
+	 * Converts a proxied URL to an unproxied URL using this proxy
+	 *
+	 * @param m {Array|String} Either the match from running this proxy's regexp against a URL,
+	 *                         or a URL string to be matched.
+	 * @type String
+	 */
+	toProper(m) {
+		if (!this.toProperScheme) return m;
+		if (!Array.isArray(m)) {
+			// make sure url has a trailing slash
+			m = new URL(m).href;
+			let match = this.regexp.exec(m);
+			if (!match) {
+				return m
+			} else {
+				m = match;
+			}
+		}
+		let hostIdx = this.parameters.indexOf("%h");
+		let protocol = m[0].indexOf('https') == 0 ? 'https://' : 'http://';
+		if (hostIdx != -1) {
+			var properURL = protocol+m[hostIdx+1]+"/";
+		} else {
+			var properURL = protocol+this.hosts[0]+"/";
+		}
+		
+		// Replace `-` with `.` in https to support EZProxy HttpsHyphens.
+		// Potentially troublesome with domains that contain dashes
+		if (protocol == "https://" ||
+			!properURL.includes('.')) {
+			properURL = properURL.replace(/-/g, '.');
+		}
+
+		if (this.indices["%p"]) {
+			properURL += m[this.parameters.indexOf("%p")+1];
+		} else {
+			var dir = m[this.parameters.indexOf("%d")+1];
+			var file = m[this.parameters.indexOf("%f")+1];
+			if (dir !== "") properURL += dir+"/";
+			properURL += file;
+		}
+
+		return properURL;
+	}
+
+	/**
+	 * Converts an unproxied URL to a proxied URL using this proxy
+	 *
+	 * @param {Object|String} uri The URI corresponding to the unproxied URL
+	 * @type String
+	 */
+	toProxy(uri) {
+		if (typeof uri == "string") {
+			uri = new URL(uri);
+			// If there's no path it is set to null, but we need
+			// at least an empty string to avoid doing many checks
+			uri.pathname = uri.pathname || '';
+		}
+		if (this.regexp?.exec(uri.href) || Zotero.Proxies._isBlacklisted(uri.hostname)) {
+			return uri.href;
+		}
+		if (this.toProxyScheme) {
+			return this.toProxyScheme.replace('%u', encodeURIComponent(uri.href));
+		}
+		var proxyURL = this.toProperScheme;
+
+		for(var i=this.parameters.length-1; i>=0; i--) {
+			var param = this.parameters[i];
+			var value = "";
+			if (param == "%h") {
+				value = (uri.protocol == 'https:') ? uri.hostname.replace(/\./g, '-') : uri.hostname;
+			} else if (param == "%p") {
+				value = uri.pathname.substr(1) + uri.search;
+			}
+
+			proxyURL = proxyURL.substr(0, this.indices[param])+value+proxyURL.substr(this.indices[param]+2);
+		}
+
+		if (proxyURL.includes('://')) {
+			return proxyURL;
+		}
+		return uri.protocol + '//' + proxyURL;
+	}
+
+	/**
+	 * For URL-rewriting proxies, detect and add host associations when navigating
+	 */
+	maybeAddHost(details) {
+		if (!this.regexp || !this.autoAssociate) return;
+		var m = this.regexp.exec(details.url);
+		if (!m) return;
+		
+		let hostParamIndex = this.parameters ? this.parameters.indexOf("%h") : -1;
+		if (hostParamIndex === -1) return;
+		
+		let host = m[hostParamIndex + 1];
+		if (!host) return;
+		// Unhyphenate host before checking it
+		if (!host.includes('.')) {
+			host = host.replace(/-/g, '.');
+		}
+
+		if (this.hosts.includes(host) || Zotero.Proxies._isBlacklisted(host)) return;
+
+		let otherProxy = Zotero.Proxies.hosts[host];
+		let shouldMapHost = !otherProxy;
+		if (otherProxy && otherProxy.toProperScheme && otherProxy.toProperScheme.substr(0, 5) != 'https') {
+			let httpsOtherProxyScheme = otherProxy.toProperScheme.replace(/^http/, 'https');
+			// If other proxy is not https, but this proxy is, we should remap the host to this proxy
+			shouldMapHost = httpsOtherProxyScheme == this.toProperScheme
+		}
+		if (!shouldMapHost) return;
+
+		if (otherProxy) {
+			otherProxy.hosts = otherProxy.hosts.filter(h => h != host);
+			Zotero.Proxies.save(otherProxy);
+		}
+		this.hosts.push(host);
+		Zotero.Proxies.save(this);
+		Zotero.Proxies.toggleRedirectLoopPrevention(false);
+
+		Zotero.Proxies.showNotification(
+			'New Zotero Proxy Host',
+			`Zotero automatically associated ${host} with a previously defined proxy. Future requests to this site will be redirected through ${this.toDisplayName()}.`,
+			["✕", "Proxy Settings", "Don’t Proxy This Site"],
+			details.tabId
+		)
+		.then((response) => {
+			if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
+			if (response == 2) {
+				this.hosts = this.hosts.filter((h) => h != host);
+				Zotero.Proxies.save(this);
+				return browser.tabs.update(details.tabId, {url: this.toProper(details.url)})
+			}
+		});
+	}
+
+	/**
+	 * For URL-rewriting proxies, perform redirect if this proxy is associated with the host
+	 */
+	maybeRedirect(details) {
+		let uri = new URL(details.url);
+		if (Zotero.Proxies.hosts[uri.host] !== this) return;
+		let proxied = this.toProxy(uri);
+		if (!proxied) return;
+		// Don't redirect https websites via http proxies
+		if (details.url.substr(0, 5) == 'https' && proxied.substr(0, 5) != 'https') return;
+		
+		var proxiedURI = new URL(proxied);
+
+		// make sure that the top two domains (e.g. gmu.edu in foo.bar.gmu.edu) of the
+		// channel and the site to which we're redirecting don't match, to prevent loops.
+		const top2DomainsRe = /[^\.]+\.[^\.]+$/;
+		let top21 = top2DomainsRe.exec(uri.hostname);
+		let top22 = top2DomainsRe.exec(proxiedURI.hostname);
+		if (!top21 || !top22 || top21[0] == top22[0]) {
+			Zotero.debug("Proxies: skipping redirect; redirect URI and URI have same top 2 domains");
+			return;
+		}
+
+		// Otherwise, redirect.
+		if (Zotero.Proxies.showRedirectNotification && ["main_frame", "outermost_frame"].includes(details.frameType)) {
+			Zotero.Proxies.showNotification(
+				'Zotero Proxy Redirection',
+				`Zotero automatically redirected your request to ${uri.host} through the proxy at ${this.toDisplayName()}.`,
+				['✕', 'Proxy Settings', "Don’t Proxy This Site"],
+				details.tabId
+			).then((response) => {
+				if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
+				if (response == 2) {
+					this.hosts = this.hosts.filter((h) => h != uri.host);
+					Zotero.Proxies.save(this);
+					// Don't redirect for hosts associated with frames
+					return browser.tabs.update(details.tabId, {url: details.url})
+				}
+			});
+		}
+
+		return {redirectUrl: proxied};
+	}
+
+	/**
+	 * Generate a display name for the proxy (e.g., "proxy.example.edu (HTTPS)")
+	 *
+	 * @return {String}
+	 */
+	toDisplayName() {
+		if (this.name) {
+			return this.name;
+		}
+		try {
+			var parts = this.toProperScheme.match(/^(?:(?:[^:]+):\/\/)?([^\/]+)/);
+			var domain = parts[1]
+				// Include part after %h, if it's present
+				.split('%h').pop()
+				// Trim leading punctuation after the %h
+				.match(/\W(.+)/)[1];
+			return domain;
+		}
+		catch (e) {
+			Zotero.logError(`Invalid proxy ${this.toProperScheme}: ${e}`);
+			return this.toProperScheme;
+		}
+	}
 }
 
-/**
- * Generate a display name for the proxy (e.g., "proxy.example.edu (HTTPS)")
- *
- * @return {String}
- */
-Zotero.Proxy.prototype.toDisplayName = function () {
-	try {
-		var parts = this.toProperScheme.match(/^(?:(?:[^:]+):\/\/)?([^\/]+)/);
-		var domain = parts[1]
-			// Include part after %h, if it's present
-			.split('%h').pop()
-			// Trim leading punctuation after the %h
-			.match(/\W(.+)/)[1];
-		return domain;
+Zotero.Proxy.OpenAthensProxy = class extends Zotero.Proxy {
+	constructor(json={}) {
+		super(json);
+		this.type = 'openathens';
+		// Regexp to match the redirect URL and capture the destination to add to hosts
+		this.toProxyRegexp = new RegExp(XRegExp.escape(this.toProxyScheme).replace('%u', '([^&]+)'));
 	}
-	catch (e) {
-		Zotero.logError(`Invalid proxy ${this.toProperScheme}: ${e}`);
-		return this.toProperScheme;
+
+	/**
+	 * Checks if the url matches the OpenAthens redirector and if so adds the host to this proxy
+	 * and disasociates it from any other proxy.
+	 * @param {Object} details 
+	 * @returns 
+	 */
+	maybeAddHost(details) {
+		if (!this.toProxyScheme || !this.autoAssociate) return;
+		let m = this.toProxyRegexp.exec(details.url);
+		if (!m) return;
+		
+		let redirectURL = decodeURIComponent(m[1]);
+		let uri = new URL(redirectURL);
+		let host = uri.host;
+		if (!host || this.hosts.includes(host) || Zotero.Proxies._isBlacklisted(host)) return;
+
+		let otherProxy = Zotero.Proxies.hosts[host];
+		if (otherProxy) {
+			// If we are redirecting to an OpenAthens host, we disassociate it from any other proxy
+			otherProxy.hosts = otherProxy.hosts.filter((h) => h != host);
+			Zotero.Proxies.save(otherProxy);
+		}
+		this.hosts.push(host);
+		Zotero.Proxies.save(this);
+		Zotero.Proxies.toggleRedirectLoopPrevention(false);
+
+		Zotero.Proxies.showNotification(
+			'New Zotero Proxy Host',
+			`Zotero automatically associated ${host} with a previously defined proxy. Future requests to this site will be redirected through ${this.toDisplayName()}.`,
+			["✕", "Proxy Settings", "Don’t Proxy This Site"],
+			details.tabId
+		)
+		.then((response) => {
+			if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
+			if (response == 2) {
+				this.hosts = this.hosts.filter((h) => h != host);
+				Zotero.Proxies.save(this);
+			}
+		});
+	}
+
+	maybeRedirect(details) {
+		let uri = new URL(details.url);
+		if (Zotero.Proxies.hosts[uri.host] !== this) return;
+		// Redirect via OpenAthens hosts every OPENATHENS_REDIRECT_INTERVAL, to make sure we are still
+		// authenticated with the provider, since we don't have a good way to check for that.
+		let last = Zotero.Proxies.openAthensHostRedirectTime[uri.host] || 0;
+		if (Date.now() - last < OPENATHENS_REDIRECT_INTERVAL) return;
+		
+		Zotero.Proxies.openAthensHostRedirectTime[uri.host] = Date.now();
+
+		if (Zotero.Proxies.showRedirectNotification && ["main_frame", "outermost_frame"].includes(details.frameType)) {
+			Zotero.Proxies.showNotification(
+				'Zotero Proxy Redirection',
+				`Zotero automatically redirected your request to ${uri.host} through the proxy at ${this.toDisplayName()}.`,
+				['✕', 'Proxy Settings', "Don’t Proxy This Site"],
+				details.tabId
+			).then((response) => {
+				if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
+				if (response == 2) {
+					this.hosts = this.hosts.filter((h) => h != uri.host);
+					Zotero.Proxies.save(this);
+				}
+			});
+		}
+		return {redirectUrl: this.toProxy(details.url)};
 	}
 }
 
@@ -1047,8 +1162,8 @@ Zotero.Proxies.Detectors.EZProxy.Listener.prototype.onHeadersReceived = function
 	if (isProxiedHost) {
 		let isExisting;
 		for (let proxy of Zotero.Proxies.proxies) {
-			isExisting = proxy.regexp.test(details.url)
-			if (isExisting) {
+			if (proxy.regexp && proxy.regexp.test(details.url)) {
+				isExisting = true;
 				if (!proxy.toProxyScheme) {
 					// Add a proxyScheme if not present
 					proxy.toProxyScheme = this.toProxy;
@@ -1063,29 +1178,46 @@ Zotero.Proxies.Detectors.EZProxy.Listener.prototype.onHeadersReceived = function
 				toProxyScheme: this.toProxy,
 				hosts: [this.properURI.host.replace(/-/g, '.')]
 			});
-			Zotero.Proxies.notifyNewProxy(proxy, details.tabId)
+			if (proxy.validate()) {
+				Zotero.Proxies.notifyNewProxy(proxy.toJSON(), details.tabId)
+			}
 		}
 		this.deregister();
 	}
 };
 
-/**
- * Detector for Juniper Networks WebVPN
- * @param {Object} details
- * @type Boolean|Zotero.Proxy
- */
-Zotero.Proxies.Detectors.Juniper = function(details) {
-	const juniperRe = /^https?:\/\/([^\/:]+(?:\:[0-9]+)?)\/(.*),DanaInfo=([^+,]*)([^+]*)(?:\+(.*))?$/;
-	var m = juniperRe.exec(details.url);
+Zotero.Proxies.Detectors.OpenAthens = function(details) {
+	var m = /^https?:\/\/go\.openathens\.net\/redirector\/([^?]*)\?url=([^&]+)/i.exec(details.url);
 	if (!m) return false;
 	
-	return new Zotero.Proxy({
+	var name = m[1];
+	var properURL = decodeURIComponent(m[2]);
+	try {
+		var properURI = new URL(properURL);
+	}
+	catch (e) {
+		return false;
+	}
+	
+	var toProxyScheme = `https://go.openathens.net/redirector/${name}?url=%u`;
+	
+	for (let proxy of Zotero.Proxies.proxies) {
+		if (proxy.toProxyScheme == toProxyScheme) {
+			// already recognized
+			return false;
+		}
+	}
+	
+	// Create an OA proxy instance; hosts are added via maybeAddHost when navigating through redirector
+	let proxy = new Zotero.Proxy.OpenAthensProxy({
+		name: name,
 		autoAssociate: true,
-		scheme: m[1]+"/%d"+",DanaInfo=%h%a+%f",
-		hosts: [m[3]]
+		toProxyScheme: toProxyScheme,
+		hosts: [properURI.host],
+		type: "openathens"
 	});
-}
-
+	return proxy;
+};
 
 Zotero.Proxies.DNS = new function() {
 	this.getHostnames = function() {

--- a/src/common/proxy.js
+++ b/src/common/proxy.js
@@ -360,7 +360,10 @@ Zotero.Proxies = new function() {
 		});
 	};
 
-
+	this.validate = function(proxy) {
+		let instance = Zotero.Proxies._createProxyInstance(proxy);
+		return instance.validate();
+	}
 
 	/**
 	 * Update proxy and host maps and store proxy settings in storage
@@ -423,7 +426,6 @@ Zotero.Proxies = new function() {
 		let proxies = Zotero.Proxies.proxies.map(function(p) {
 			return {
 				id: p.id,
-				name: p.name,
 				autoAssociate: p.autoAssociate,
 				toProxyScheme: p.toProxyScheme,
 				toProperScheme: p.toProperScheme || p.scheme,
@@ -653,7 +655,6 @@ Zotero.Proxy = class {
 		this.id = json.id || Date.now();
 		// Whether hosts should be automatically associated with this proxy
 		this.autoAssociate = json.autoAssociate !== false;
-		this.name = json.name;
 		this.toProperScheme = json.toProperScheme || json.scheme;
 		// Proxy login URL with %u where the URL to-be-proxied should be inserted
 		this.toProxyScheme = json.toProxyScheme;
@@ -666,11 +667,11 @@ Zotero.Proxy = class {
 	}
 
 	validate() {
-		for (let host in this.hosts) {
+		for (let host of this.hosts) {
 			host = host.trim();
 			var oldProxy = Zotero.Proxies.hosts[host];
 			if (oldProxy && oldProxy.id != this.id) {
-				return ["host.proxyExists", host];
+				return ["proxy_validate_hostProxyExists", host];
 			}
 		}
 
@@ -679,30 +680,32 @@ Zotero.Proxy = class {
 			for (let p of Zotero.Proxies.proxies) {
 				if (!p || p.id == this.id) continue;
 				if ((p.toProxyScheme || '').trim() && (p.toProxyScheme || '').trim() == scheme) {
-					return ["scheme.duplicate"];
+					return ["proxy_validate_schemeDuplicate"];
 				}
 			}
 		}
 		
 		if (!this.toProperScheme) return false;
 
+		// Unmodified
+		if (this.toProperScheme == '%h.example.com/%p' || this.toProxyScheme == 'proxy.example.com/login?qurl=%s') {
+			return ["proxy_validate_schemeUnmodified"];
+		}
+
 		if (
 			// Scheme very short
 			this.toProperScheme.length <= "%h.-.--/%p".length 
-				// Unmodified
-				|| this.toProperScheme == '%h.example.com/%p'
-				|| this.toProxyScheme == 'proxy.example.com/login?qurl=%s'
 				// Host is at the end of the domain part of the scheme
 				|| this.toProperScheme.includes('%h/')
 				// No-op proxy schemes that don't actually proxy anything (see #492)
 				|| this.toProperScheme == '%h/%p'
 				|| this.toProperScheme == '%h%p'
 		) {
-			return ["scheme.invalid"];
+			return ["proxy_validate_schemeInvalid"];
 		}
 
 		if (!Zotero_Proxy_schemeParameterRegexps["%p"].test(this.toProperScheme)) {
-			return ["scheme.noPath"];
+			return ["proxy_validate_schemeNoPath"];
 		}
 		return false;
 	}
@@ -757,7 +760,6 @@ Zotero.Proxy = class {
 	toJSON() {
 		return {
 			id: this.id,
-			name: this.name,
 			autoAssociate: this.autoAssociate,
 			toProxyScheme: this.toProxyScheme,
 			toProperScheme: this.toProperScheme,
@@ -954,8 +956,8 @@ Zotero.Proxy = class {
 	 * @return {String}
 	 */
 	toDisplayName() {
-		if (this.name) {
-			return this.name;
+		if (this.type === 'openathens') {
+			return this.toProxyScheme.match(/\/redirector\/([^?]+)/)[1];
 		}
 		try {
 			var parts = this.toProperScheme.match(/^(?:(?:[^:]+):\/\/)?([^\/]+)/);
@@ -1210,7 +1212,6 @@ Zotero.Proxies.Detectors.OpenAthens = function(details) {
 	
 	// Create an OA proxy instance; hosts are added via maybeAddHost when navigating through redirector
 	let proxy = new Zotero.Proxy.OpenAthensProxy({
-		name: name,
 		autoAssociate: true,
 		toProxyScheme: toProxyScheme,
 		hosts: [properURI.host],

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -56,10 +56,12 @@ Zotero.Utilities.Connector = {
 			set: function (target, prop, value) {
 				target[prop] = value;
 				browser.storage.session.set({[name]: JSON.stringify(target)});
+				return target[prop];
 			},
 			deleteProperty: function(target, prop) {
 				delete target[prop];
 				browser.storage.session.set({[name]: JSON.stringify(target)});
+				return true;
 			}
 		})
 	},

--- a/src/messages.json
+++ b/src/messages.json
@@ -285,6 +285,19 @@
 	"reloadVia": {
 		"message": "Reload via $1"
 	},
+
+	"proxy_validate_hostProxyExists": {
+		"message": "A proxy is already defined for $1. Please remove the entry in the existing proxy or change the hostname."
+	},
+	"proxy_validate_schemeDuplicate": {
+		"message": "A proxy with the same login URL scheme is already defined. Please remove the existing proxy or change the login URL scheme."
+	},
+	"proxy_validate_schemeInvalid": {
+		"message": "The Proxied URL scheme is invalid. Please enter a valid proxied URL scheme."
+	},
+	"proxy_validate_schemeNoPath": {
+		"message": "The login URL scheme does not contain a path (%p). Please enter a valid login URL scheme."
+	},
 	
 	"permissions_siteAccess_title": {
 		"message": "Site Access Permissions Required"


### PR DESCRIPTION
Closes #571

As per the issue, implements OpenAthens proxy support, by checking for navigation via the redirector. A proxy is automatically added and will be identified by `https://go.openathens.net/redirector/[PROXY_URL]?url=`. Then when navigating to associated hostnames, we auto-redirect via the redirector every 12 hours.

Added a switch to proxy settings that allows to switch between EZProxy and OpenAthens proxies. Also some misc CSS updates and refactoring in the preferences.

I've also changed the logic of proxies, such that if there are multiple proxies, we will automatically steal hostnames from one proxy to another when a hostname is detected to be used with one of the proxies.

I'll also have a PR after this is merged that fully localizes preferences page and the rest of the strings in the connector (but it depends on the changes here).