### PR TITLE
Safari: Suggest to open Zotero if it's closed when saving

### DIFF
--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -290,6 +290,33 @@ Zotero.Connector = new function() {
 		return this.callMethod(options, data);
 	}
 
+	this.openZotero = async function() {
+		if (!Zotero.isSafari) {
+			return false;
+		}
+
+		const waitToOpen = 10e3; // 10 seconds
+		const waitInterval = 500; // 500ms
+		try {
+			Zotero.Messaging.sendMessage('Swift.openZotero');
+			Zotero.debug(`Attempting to open Zotero, waiting for it to become online for ${waitToOpen}ms`);
+
+			for (let i = 0; i < waitToOpen / waitInterval; i++) {
+				await Zotero.Promise.delay(waitInterval);
+				if (await this.checkIsOnline()) {
+					Zotero.debug("Zotero opened successfully");
+					return true;
+				}
+			}
+			Zotero.debug("Waiting for Zotero to become online timed out");
+			return false;
+		} catch (e) {
+			Zotero.debug("Error opening Zotero");
+			Zotero.logError(e);
+			return false;
+		}
+	}
+
 	/**
 	 * If running an integration method check if the tab is still available to receive
 	 * a response from Zotero and if not - respond with an error message so that

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -317,7 +317,7 @@ let PageSaving = {
 	 * @returns {Promise<*>}
 	 */
 	async saveAsWebpage({ title=document.title, snapshot: saveSnapshot=true } = {}) {
-		var result = await Zotero.Inject.checkActionToServer();
+		var result = await Zotero.Inject.handleZoteroIsOffline();
 		if (!result) return;
 
 		const isOnline = await Zotero.Connector.checkIsOnline();
@@ -537,7 +537,7 @@ let PageSaving = {
 	 * with selection as a note.
 	 */
 	async onTranslate(translatorID, options={}) {
-		let result = await Zotero.Inject.checkActionToServer();
+		let result = await Zotero.Inject.handleZoteroIsOffline();
 		if (!result) return;
 		let translatorIndex = this.translators.findIndex(t => t.translatorID === translatorID);
 		let translator = this.translators[translatorIndex];
@@ -625,7 +625,7 @@ let PageSaving = {
 	 * Entry point for clicking on the Zotero button to save when no translators are available
 	 */
 	async onSaveAsWebpage([ title=document.title, options={} ]) {
-		var result = await Zotero.Inject.checkActionToServer();
+		var result = await Zotero.Inject.handleZoteroIsOffline();
 		if (!result) return;
 
 		Zotero.debug(`PageSaving.onSaveAsWebpage: Saving webpage, ${JSON.stringify(options)}`);

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -351,6 +351,7 @@ if (Zotero.isSafari) {
 		onTabData: true,
 		getExtensionVersion: true
 	});
+	MESSAGES.Connector.openZotero = true;
 }
 
 // Chrome does not support passing arrayBuffers via the message

--- a/src/common/preferences/preferences.html
+++ b/src/common/preferences/preferences.html
@@ -38,6 +38,14 @@
 			</div>
 		</div>
 		<div id="content-general" class="content">
+			<div class="group" id="group-general-prefs" style="display: none">
+				<div class="group-title">General</div>
+				<div class="group-content">
+					<p>
+						<label><input type="checkbox" data-pref="shouldOpenZotero"/>&nbsp;Allow Zotero Connector to automatically open Zotero when saving pages</label>
+					</p>
+				</div>
+			</div>
 			<div class="group">
 				<div class="group-title">Zotero Status</div>
 				<div class="group-content" id="client-status"></div>

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -164,6 +164,11 @@ Zotero_Preferences.General = {
 			ReactDOM.render(this.mimeTypeHandlingComponent, elem.querySelectorAll('.group-content')[0]);
 		}
 
+		if (Zotero.isSafari) {
+			let groupGeneralPrefs = document.getElementById('group-general-prefs');
+			if (groupGeneralPrefs) groupGeneralPrefs.style.display = null;
+		}
+
 		ReactDOM.render(React.createElement(Zotero_Preferences.Components.ClientStatus, null),
 			document.getElementById("client-status"));
 		document.getElementById("general-button-clear-credentials").onclick = Zotero_Preferences.General.clearCredentials;

--- a/src/common/zotero.js
+++ b/src/common/zotero.js
@@ -346,6 +346,7 @@ Zotero.Prefs = new function() {
 		"allowedInterceptHosts": [],
 		"firstUse": true,
 		"firstSaveToServer": true,
+		"shouldOpenZotero": false,
 		"reportTranslationFailure": true,
 		"translatorMetadata": [],
 		

--- a/src/messages.json
+++ b/src/messages.json
@@ -191,6 +191,13 @@
 		"description": "The Accept button for the first-run dialog"
 	},
 	
+	"openZotero_title": {
+		"message": "Open Zotero?"
+	},
+	"openZotero_message": {
+		"message": "Zotero is not open. Would you like the Zotero Connector to open Zotero automatically?"
+	},
+	
 	"error_connection_isAppRunning": {
 		"message": "Is $1 Running?"
 	},


### PR DESCRIPTION
Closes zotero/safari-app-extension#8

<img width="969" height="674" alt="image" src="https://github.com/user-attachments/assets/1041257c-c7fd-47e1-acb1-59600de8e268" />

Only need to click OK once, and a pref is set. 

If Zotero fails to launch in 10s, or if you press cancel, you are shown another prompt as before:

<img width="969" height="674" alt="Image" src="https://github.com/user-attachments/assets/165dea70-a973-45d2-ad56-a35a128038ec" />

Pref:

<img width="969" height="674" alt="Image" src="https://github.com/user-attachments/assets/183bdff7-7c17-46d9-8194-c75732968cc9" />
