### PR TITLE
fix: Update broken MDN links (developer.mozilla.org restructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ An overview of the Zotero Connector architecture.
 ##### Chrome/Firefox Browser Extension Framework
 
 The extension uses the WebExtension API cross-browser technology. See [Chrome Extension docs](https://developer.chrome.com/extensions)
-and [Firefox Extension docs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) for more information.
+and [Firefox Extension docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions) for more information.
 
 ##### Safari Extension Framework
 
@@ -73,7 +73,7 @@ code running on the webpage and a background process.
 
 ##### a) Injected scripts for individual webpages
 
-Each webpage is injected ([Chrome](https://developer.chrome.com/extensions/content_scripts)/[Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts)/[Safari](https://developer.apple.com/documentation/safariservices/injecting-a-script-into-a-webpage))
+Each webpage is injected ([Chrome](https://developer.chrome.com/extensions/content_scripts)/[Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)/[Safari](https://developer.apple.com/documentation/safariservices/injecting-a-script-into-a-webpage))
 with a full Zotero [translation framework](https://github.com/zotero/zotero-connectors/blob/e1a16c8ad2e17c6893554c3f376384e18182202d/gulpfile.js#L45-L79).
 A [*Zotero.Translate.Web*](https://github.com/zotero/zotero-connectors/blob/e1a16c8ad2e17c6893554c3f376384e18182202d/src/common/inject/inject.jsx#L314-L314) 
 instance orchestrates running individual translators for detection and translation.
@@ -87,7 +87,7 @@ framework, such as retrieving translator code and sending translated items eithe
 ##### b) Background process
 
 The Connector runs a [background process](https://github.com/zotero/zotero-connectors/blob/e1a16c8ad2e17c6893554c3f376384e18182202d/gulpfile.js#L95-L125) 
-([Chrome](https://developer.chrome.com/extensions/event_pages)/[Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts)/[Safari](https://developer.apple.com/documentation/safariservices/building-a-safari-app-extension))
+([Chrome](https://developer.chrome.com/extensions/event_pages)/[Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts)/[Safari](https://developer.apple.com/documentation/safariservices/building-a-safari-app-extension))
 which works as a middle-layer between the translation framework running in inject scripts (a) and Zotero (c) or zotero.org (d).
 
 The background process maintains a cache of translators and performs the initial [translator detection using URL matching](https://github.com/zotero/zotero-connectors/blob/e1a16c8ad2e17c6893554c3f376384e18182202d/src/common/translators.js#L140-L196).
@@ -118,7 +118,7 @@ The interactions with zotero.org API are defined in [api.js](https://github.com/
 ## Message passing
 
 The only way for the background extension process and injected scripts to communicate is using the message passing
-protocol provided by the browsers ([Chrome](https://developer.chrome.com/extensions/messaging)/[Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts#Communicating_with_background_scripts)/[Safari](https://developer.apple.com/documentation/safariservices/passing-messages-between-safari-app-extensions-and-injected-scripts)). 
+protocol provided by the browsers ([Chrome](https://developer.chrome.com/extensions/messaging)/[Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communicating_with_background_scripts)/[Safari](https://developer.apple.com/documentation/safariservices/passing-messages-between-safari-app-extensions-and-injected-scripts)). 
 Injected scripts often need to communicate to background scripts. To simplify
 these interactions, calls to functions in background scripts are monkey-patched in injected scripts. These calls are
 asynchronous and if a return value is required, it is provided either to a callback function as the last argument of

--- a/src/common/connector.js
+++ b/src/common/connector.js
@@ -244,7 +244,7 @@ Zotero.Connector = new function() {
 			//
 			// https://github.com/zotero/zotero-connectors/issues/226
 			//
-			// [1] https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/getAll
+			// [1] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll
 			// [2] https://bugzilla.mozilla.org/show_bug.cgi?id=1315558
 			if (Zotero.isFirefox && Zotero.browserMajorVersion >= 59) {
 				cookieParams.firstPartyDomain = null;

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -150,7 +150,7 @@ Zotero.HTTP = new function() {
 			// cross-domain request, we can use the content XHR that it provides, which does
 			// include Referer. Chrome's XHR in content scripts includes Referer by default.
 			//
-			// [1] https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts#XHR_and_Fetch
+			// [1] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#XHR_and_Fetch
 			if (Zotero.HTTP.isSameOrigin(url) && !(Zotero.isSafari && options.headers['User-Agent'])) {
 				if (typeof content != 'undefined' && content.XMLHttpRequest) {
 					Zotero.debug("Using content XHR");


### PR DESCRIPTION
## Summary

Mozilla restructured developer.mozilla.org URLs. This PR updates 6 broken links:

### Changes
- `developer.mozilla.org/en-US/Add-ons/WebExtensions` → `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions`
- `developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts` → `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts`
- `developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts` → `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts`
- `developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts#Communicating_with_background_scripts` → `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communicating_with_background_scripts`
- `developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/getAll` → `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll`
- `developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts#XHR_and_Fetch` → `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#XHR_and_Fetch`

### Files changed
- README.md (4 links)
- src/common/connector.js (1 link)
- src/common/http.js (1 link)

---
*PR created by @theluckystrike for Zovo (zovo.one)*