### PR TITLE
feat(progress-window): support optional attachment transfer stats and…

### DIFF
--- a/src/common/itemSaver.js
+++ b/src/common/itemSaver.js
@@ -405,7 +405,39 @@ ItemSaver.prototype = {
 
 		return false;
 	},
-
+	
+	/**
+	 * Fetch optional attachment transfer stats from a Desktop plugin endpoint.
+	 * This endpoint is intentionally optional and silently ignored if missing.
+	 *
+	 * Expected response shape:
+	 *   { attachments: { [attachmentID]: { downloadedBytes, totalBytes, rateBps, etaSec } } }
+	 * or:
+	 *   { [attachmentID]: { downloadedBytes, totalBytes, rateBps, etaSec } }
+	 *
+	 * @param {String} sessionID
+	 * @returns {Promise<Object|null>}
+	 */
+	_fetchAttachmentTransferStats: async function(sessionID) {
+		try {
+			let response = await Zotero.Connector.callMethod({
+				method: "attachmentDownloadProgress",
+				timeout: 300
+			}, { sessionID });
+			if (!response || typeof response != 'object') {
+				return null;
+			}
+			if (response.attachments && typeof response.attachments == 'object') {
+				return response.attachments;
+			}
+			return response;
+		}
+		catch (e) {
+			// The plugin endpoint is optional; ignore endpoint missing/unavailable errors.
+			return null;
+		}
+	},
+	
 	/**
 	 * Polls for updates to attachment progress
 	 * @param items Items in Zotero.Item.toArray() format
@@ -439,12 +471,17 @@ ItemSaver.prototype = {
 				return;
 			}
 			
+			let transferStatsByID = await this._fetchAttachmentTransferStats(this._sessionID);
+			
 			// Store last version of attachments so we can cancel them if a subsequent request fails
 			let newAttachments = [];
 			for (let item of response.items) {
 				if (!item.attachments) continue;
 				for (let attachment of item.attachments) {
 					attachment.parentItem = item.id;
+					if (transferStatsByID && attachment.id && transferStatsByID[attachment.id]) {
+						Object.assign(attachment, transferStatsByID[attachment.id]);
+					}
 					attachmentCallback(attachment, attachment.progress);
 					newAttachments.push(attachment);
 				}

--- a/src/common/preferences/preferences.html
+++ b/src/common/preferences/preferences.html
@@ -65,6 +65,25 @@
 				<!-- React Component -->
 				<div class="group-content"></div>
 			</div>
+			<div class="group">
+				<div class="group-title">Download Progress Display</div>
+				<div class="group-content">
+					<p>
+						<label>
+							<input type="checkbox" id="general-checkbox-show-download-stats"/>
+							&nbsp;Show attachment download details (progress, speed, size)
+						</label>
+					</p>
+					<p>
+						<label for="general-select-download-locale">Progress language / 进度语言：</label>
+						<select id="general-select-download-locale">
+							<option value="auto">Auto (Browser)</option>
+							<option value="zh-CN">中文</option>
+							<option value="en-US">English</option>
+						</select>
+					</p>
+				</div>
+			</div>
 		</div>
 		<!-- React Component -->
 		<div id="content-proxies" class="content"></div>

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -161,9 +161,39 @@ Zotero_Preferences.General = {
 		ReactDOM.render(React.createElement(Zotero_Preferences.Components.ClientStatus, null),
 			document.getElementById("client-status"));
 		document.getElementById("general-button-clear-credentials").onclick = Zotero_Preferences.General.clearCredentials;
+		Zotero_Preferences.General.initDownloadProgressSettings();
 
 		Zotero.API.getUserInfo().then(Zotero_Preferences.General.updateAuthorization);
 
+	},
+
+	initDownloadProgressSettings: function() {
+		const showStatsCheckbox = document.getElementById('general-checkbox-show-download-stats');
+		const localeSelect = document.getElementById('general-select-download-locale');
+		if (!showStatsCheckbox || !localeSelect) return;
+
+		Zotero.Prefs.getAsync('progressWindow.showDownloadStats').then((value) => {
+			if (value === null || typeof value == 'undefined') {
+				value = true;
+				Zotero.Prefs.set('progressWindow.showDownloadStats', value);
+			}
+			showStatsCheckbox.checked = !!value;
+		});
+
+		Zotero.Prefs.getAsync('progressWindow.downloadLocale').then((value) => {
+			if (!value) {
+				value = 'auto';
+				Zotero.Prefs.set('progressWindow.downloadLocale', value);
+			}
+			localeSelect.value = value;
+		});
+
+		showStatsCheckbox.addEventListener('change', (event) => {
+			Zotero.Prefs.set('progressWindow.showDownloadStats', event.target.checked);
+		});
+		localeSelect.addEventListener('change', (event) => {
+			Zotero.Prefs.set('progressWindow.downloadLocale', event.target.value || 'auto');
+		});
 	},
 
 	/**

--- a/src/common/progressWindow/progressWindow.css
+++ b/src/common/progressWindow/progressWindow.css
@@ -269,6 +269,20 @@ button:active {
 	text-overflow: ellipsis
 }
 
+.ProgressWindow-itemTextWrap {
+	flex: 1;
+	min-width: 0;
+}
+
+.ProgressWindow-itemMeta {
+	font-size: 11px;
+	color: #666;
+	margin: 2px 0 0 22px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .ProgressWindow-error {
 	font-size: 13px;
 	line-height: 1.4em;

--- a/src/common/ui/ProgressWindow.jsx
+++ b/src/common/ui/ProgressWindow.jsx
@@ -62,6 +62,8 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		this.done = false;
 		this.canUserAddNote = false;
 		this.supportsTagsAutocomplete = false;
+		this.downloadLocalePref = "auto";
+		this.showDownloadStats = true;
 		
 		this.text = {
 			more: Zotero.getString('general_more'),
@@ -143,6 +145,13 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		});
 		Zotero.Connector.getPref('supportsTagsAutocomplete').then(res => {
 			this.supportsTagsAutocomplete = res;
+		});
+		Zotero.Prefs.getAsync('progressWindow.downloadLocale').then((locale) => {
+			this.downloadLocalePref = locale || "auto";
+		});
+		Zotero.Prefs.getAsync('progressWindow.showDownloadStats').then((showStats) => {
+			// Default to true if preference has not been set yet
+			this.showDownloadStats = showStats !== false;
 		});
 		// Present scrollbar from briefly appearing when tags are being added
 		document.documentElement.style.scrollbarWidth = 'none';
@@ -283,12 +292,102 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 			if (params.itemType) {
 				p.itemType = params.itemType
 			}
+			let downloadedBytes = params.downloadedBytes;
+			if (typeof downloadedBytes != 'number' && typeof params.downloaded == 'number') {
+				downloadedBytes = params.downloaded;
+			}
+			if (typeof downloadedBytes == 'number') {
+				p.downloadedBytes = downloadedBytes;
+			}
+			let totalBytes = params.totalBytes;
+			if (typeof totalBytes != 'number' && typeof params.total == 'number') {
+				totalBytes = params.total;
+			}
+			if (typeof totalBytes == 'number') {
+				p.totalBytes = totalBytes;
+			}
+			let rateBps = params.rateBps;
+			if (typeof rateBps != 'number' && typeof params.rate == 'number') {
+				rateBps = params.rate;
+			}
+			if (typeof rateBps == 'number') {
+				p.rateBps = rateBps;
+			}
+			if (typeof params.etaSec == 'number') {
+				p.etaSec = params.etaSec;
+			}
 			return newState;
 		});
 		// Do not being announcing alerts until all top level items are loaded
 		if (!this.announceAlerts) {
 			this.announceAlerts = params.itemsLoaded;
 		}
+	}
+
+	getEffectiveDownloadLocale() {
+		if (this.downloadLocalePref && this.downloadLocalePref != 'auto') {
+			return this.downloadLocalePref;
+		}
+		return navigator.language || 'en-US';
+	}
+
+	isChineseDownloadLocale() {
+		return this.getEffectiveDownloadLocale().toLowerCase().startsWith('zh');
+	}
+
+	formatBytes(bytes) {
+		if (typeof bytes != 'number' || !isFinite(bytes) || bytes < 0) return '';
+		let units = ['B', 'KB', 'MB', 'GB', 'TB'];
+		let idx = 0;
+		let val = bytes;
+		while (val >= 1024 && idx < units.length - 1) {
+			val /= 1024;
+			idx++;
+		}
+		let digits = idx <= 1 ? 0 : 1;
+		return `${val.toFixed(digits)} ${units[idx]}`;
+	}
+
+	formatRate(rateBps) {
+		let bytes = this.formatBytes(rateBps);
+		if (!bytes) return '';
+		return this.isChineseDownloadLocale() ? `${bytes}/秒` : `${bytes}/s`;
+	}
+
+	formatEta(etaSec) {
+		if (typeof etaSec != 'number' || !isFinite(etaSec) || etaSec < 0) return '';
+		let total = Math.round(etaSec);
+		let min = Math.floor(total / 60);
+		let sec = total % 60;
+		if (this.isChineseDownloadLocale()) {
+			return min > 0 ? `剩余 ${min}分${sec}秒` : `剩余 ${sec}秒`;
+		}
+		return min > 0 ? `${min}m ${sec}s left` : `${sec}s left`;
+	}
+
+	getProgressMeta(item) {
+		if (!this.showDownloadStats || !item.parentItem) return '';
+		let parts = [];
+		if (typeof item.percentage == 'number' && item.percentage >= 0 && item.percentage < 100) {
+			parts.push(`${Math.round(item.percentage)}%`);
+		}
+		let downloaded = this.formatBytes(item.downloadedBytes);
+		let total = this.formatBytes(item.totalBytes);
+		if (downloaded && total) {
+			parts.push(`${downloaded} / ${total}`);
+		}
+		else if (downloaded) {
+			parts.push(downloaded);
+		}
+		let rate = this.formatRate(item.rateBps);
+		if (rate) {
+			parts.push(rate);
+		}
+		let eta = this.formatEta(item.etaSec);
+		if (eta) {
+			parts.push(eta);
+		}
+		return parts.join(this.isChineseDownloadLocale() ? ' | ' : ' | ');
 	}
 	
 	addError() {
@@ -982,12 +1081,20 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 				backgroundSize: "contain"
 			},
 		);
+		var progressMeta = this.getProgressMeta(item);
 		
 		return (
 			<div key={item.id} className="ProgressWindow-item" style={itemStyle}>
 				<div className="ProgressWindow-itemIcon" style={iconStyle}></div>
-				<div className="ProgressWindow-itemText">
-					{item.title}
+				<div className="ProgressWindow-itemTextWrap">
+					<div className="ProgressWindow-itemText">
+						{item.title}
+					</div>
+					{progressMeta ? (
+						<div className="ProgressWindow-itemMeta">
+							{progressMeta}
+						</div>
+					) : null}
 				</div>
 			</div>
 		);


### PR DESCRIPTION
## Problem
The connector progress window currently shows attachment save progress as a percentage, but it does not display transfer throughput or byte-level progress. For long PDF/EPUB downloads, users cannot tell whether a download is actively progressing, how fast it is, or how much data remains.

In practice, byte/throughput metrics are often only available on the Zotero client side during attachment transfer. The connector should be able to consume these metrics when available, without creating a hard dependency on client/plugin-specific implementations.

## Proposed Solution
This PR adds an optional enhancement path:

1. Connector continues polling `/connector/sessionProgress` as before.
2. Connector additionally tries (best-effort) to call `/connector/attachmentDownloadProgress` with `{ sessionID }`.
3. If the endpoint exists and returns stats keyed by attachment ID, connector merges the following fields into attachment progress updates:
- `downloadedBytes`
- `totalBytes`
- `rateBps`
- `etaSec`
4. Progress UI renders these fields when present.
5. If endpoint is missing/unavailable, behavior remains unchanged.

### UI additions
- Attachment rows can show secondary metadata line (progress %, bytes, speed, ETA).
- Preferences:
- `progressWindow.showDownloadStats` (default: `true`)
- `progressWindow.downloadLocale` (`auto` / `zh-CN` / `en-US`)

## Why This Design
- No protocol break: existing `sessionProgress` flow is untouched.
- No hard dependency: optional endpoint is silently ignored if absent.
- Works with current/future client implementations that can expose richer transfer stats.
- Backward compatible with older clients and existing connector behavior.

## Compatibility
- Backward compatibility: preserved.
- If `/connector/attachmentDownloadProgress` is not implemented, connector behaves exactly as today.
- If implemented partially, connector uses only present fields.
- Existing `progress` semantics (including `false` on failure) are unchanged.

## Data Contract (optional endpoint)
Request:
```json
{ "sessionID": "<string>" }
```

Response (either shape is accepted):
```json
{
  "attachments": {
    "<attachmentID>": {
      "downloadedBytes": 12345,
      "totalBytes": 45678,
      "rateBps": 204800,
      "etaSec": 12
    }
  }
}
```

or
```json
{
  "<attachmentID>": {
    "downloadedBytes": 12345,
    "totalBytes": 45678,
    "rateBps": 204800,
    "etaSec": 12
  }
}
```

## Implementation Scope
- Connector-side only:
- merge optional transfer stats in `ItemSaver._pollForProgress()`
- render transfer metadata in progress window UI
- add preferences for display toggle and locale override

No mandatory client-side API changes are required in this PR.

## Test Matrix

1. No optional endpoint (legacy behavior)
- Setup: client does not expose `/connector/attachmentDownloadProgress`
- Expected:
- no errors
- progress window remains functional
- no speed/byte metadata shown

2. Optional endpoint available with valid stats
- Setup: endpoint returns all fields for active attachments
- Expected:
- metadata line shows bytes/speed/ETA
- updates refresh during polling
- completion state remains correct

3. Optional endpoint returns partial stats
- Setup: missing one or more fields (`etaSec`, `totalBytes`, etc.)
- Expected:
- UI renders available fields only
- no crashes or malformed output

4. Endpoint intermittent failure/timeout
- Setup: endpoint occasionally throws/returns 500/timeout
- Expected:
- connector silently falls back for that poll cycle
- no user-visible errors
- base `sessionProgress` flow unaffected

5. Multiple attachments in same session
- Setup: parallel attachment downloads
- Expected:
- stats map by attachment ID applies correctly per row
- no cross-row leakage

6. Failure path
- Setup: attachment download fails (`progress=false`)
- Expected:
- failure UI unchanged
- optional stats do not override failure semantics

7. Locale and settings
- Setup:
- `showDownloadStats=true/false`
- `downloadLocale=auto/zh-CN/en-US`
- Expected:
- metadata visible only when enabled
- locale preference applied to speed/ETA formatting

## Risk Assessment
- Low protocol risk (additive, optional).
- Low runtime risk (best-effort call with guarded error handling).
- Moderate UI risk (formatting/overflow), mitigated by truncation styling and fallback rendering.

## Follow-ups (separate PRs)
- Add automated tests for optional endpoint merge behavior.
- Standardize optional endpoint in client docs if maintainers want to formalize this contract.