### PR TITLE
Improve cross-origin request handling in http.js

### DIFF
--- a/src/common/http.js
+++ b/src/common/http.js
@@ -281,33 +281,17 @@ Zotero.HTTP = new function() {
 	
 	this._requestFetch = async function(method, url, options) {
 		if (Zotero.isInject) {
-			// Make a cross-origin request via the background page, parsing the responseText with
-			// DOMParser and returning a Proxy with 'response' set to the parsed document
-			let isDocRequest = options.responseType == 'document';
-			let coOptions = Object.assign({}, options);
-			if (isDocRequest) {
+			// Make a cross-origin request via the background page
+			const coOptions = Object.assign({}, options);
+			if (options.responseType == 'document') {
 				coOptions.responseType = 'text';
 			}
 			if (Zotero.isSafari && options.headers['User-Agent']) {
 				coOptions.headers['Cookie'] = document.cookie;
 			}
-			return Zotero.COHTTP.request(method, url, coOptions).then(function (xmlhttp) {
-				if (!isDocRequest || Zotero.isManifestV3) {
-					xmlhttp.responseType = options.responseType;
-					return xmlhttp;
-				}
-				
-				Zotero.debug("Parsing cross-origin response for " + url);
-				let parser = new DOMParser();
-				let contentType = xmlhttp.getResponseHeader("Content-Type");
-				let doc = parser.parseFromString(xmlhttp.responseText, Zotero.HTTP.determineDOMParserContentType(contentType));
-				
-				return new Proxy(xmlhttp, {
-					get: function (target, name) {
-						return name == 'response' ? doc : target[name];
-					}
-				});
-			});
+			const xmlhttp = await Zotero.COHTTP.request(method, url, coOptions);
+			xmlhttp.responseType = options.responseType;
+			return xmlhttp;
 		}
 		
 		try {
@@ -370,7 +354,7 @@ Zotero.HTTP = new function() {
 					method,
 					headers: options.headers,
 					body: options.body,
-					credentials: Zotero.isInject ? 'same-origin' : 'include',
+					credentials: 'include',
 				}
 				if (abortController) {
 					fetchOptions.signal = abortController.signal;


### PR DESCRIPTION
The method `_requestFetch` is only called if `isManifestV3 = true`, so the body of the method can be simplified a bit (no proxy + parser needed)

May I ask why in MV3 all http requests are performed via the background script, while the old `_requestXHR` method performs the request from the content script if it's not a cross-domain request (otherwise it's also done via the background)? I'm asking as I have problems with some requests that don't seem to work in the background script [with MV3 but on Firefox], but work well from the content script.

Finally, I wanted to mention that the current behavior to allow the content script to pass the requested url seems to be quite insecure (see https://developer.chrome.com/docs/extensions/develop/concepts/network-requests#xhr-vs-content-scripts). An attacker could inject a malicious content script/webpage script that sends the `co-http` request to the zotero background page and thereby perform arbitrary cross-domain requests. 