### PR TITLE
Localize the rest of strings

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -261,12 +261,11 @@ Zotero.Connector_Browser = new function() {
 	 */
 	this.onIncompatibleStandaloneVersion = function(connectorVersion, clientVersion) {
 		if (_incompatibleVersionMessageShown) return;
-		alert('Zotero Connector ' + connectorVersion + ' is incompatible with the running '
-			+ 'version of the Zotero client' + (clientVersion ? " (" + clientVersion + ")" : "")
-			+ '. Zotero Connector will continue to operate, but functionality that relies upon '
-			+ 'the Zotero client may be unavailable.\n\n'
-			+ 'Please ensure that you have installed the latest version of these components. See '
-			+ 'https://www.zotero.org/download for more details.');
+		alert(Zotero.getString('browserAction_incompatibleVersion', [
+			ZOTERO_CONFIG.CLIENT_NAME,
+			connectorVersion,
+			clientVersion ? " (" + clientVersion + ")" : ""
+		]));
 		_incompatibleVersionMessageShown = true;
 	}
 
@@ -808,16 +807,16 @@ Zotero.Connector_Browser = new function() {
 			var icon, title;
 			if (isOnline) {
 				icon = "images/zotero-new-z-16px.png";
-				title = "Zotero is Online";
+				title = Zotero.getString('browserAction_status_online', ZOTERO_CONFIG.CLIENT_NAME);
 			}
 			else if (isOnline === null) {
 				// Zotero's status is unknown without localhost access, so don't claim it's offline
 				icon = "images/zotero-new-z-16px.png";
-				title = "Zotero Connector";
+				title = Zotero.getString('appConnector', ZOTERO_CONFIG.CLIENT_NAME);
 			}
 			else {
 				icon = "images/zotero-z-16px-offline.png";
-				title = "Zotero is Offline";
+				title = Zotero.getString('browserAction_status_offline', ZOTERO_CONFIG.CLIENT_NAME);
 			}
 			if (typeof message === 'string') {
 				title = message;
@@ -867,7 +866,9 @@ Zotero.Connector_Browser = new function() {
 		});
 		let withSnapshot = Zotero.Connector.isOnline ? Zotero.Connector.prefs.automaticSnapshots :
 			Zotero.Prefs.get('automaticSnapshots');
-		let title = `Save to Zotero (Web Page ${withSnapshot ? 'with' : 'without'} Snapshot)`;
+		let title = Zotero.getString(withSnapshot
+			? 'browserAction_saveWebpageWithSnapshot'
+			: 'browserAction_saveWebpageWithoutSnapshot', ZOTERO_CONFIG.CLIENT_NAME);
 		browser.action.setTitle({tabId: tab.id, title});
 	}
 
@@ -878,7 +879,7 @@ Zotero.Connector_Browser = new function() {
 		});
 		browser.action.setTitle({
 			tabId: tab.id,
-			title: "Save to Zotero (PDF)"
+			title: Zotero.getString('browserAction_savePDF', ZOTERO_CONFIG.CLIENT_NAME)
 		});
 	}
 
@@ -897,7 +898,7 @@ Zotero.Connector_Browser = new function() {
 		if (translators[0].itemType == "multiple") return;
 		browser.contextMenus.create({
 			id: "zotero-context-menu-translator-save-with-selection-note",
-			title: "Create Zotero Item and Note from Selection",
+			title: Zotero.getString('contextMenu_saveWithNote', ZOTERO_CONFIG.CLIENT_NAME),
 			parentId: parentID,
 			contexts: ['selection']
 		});
@@ -907,13 +908,13 @@ Zotero.Connector_Browser = new function() {
 		var fns = [];
 		fns.push(() => browser.contextMenus.create({
 			id: "zotero-context-menu-webpage-withSnapshot-save",
-			title: "Save to Zotero (Web Page with Snapshot)",
+			title: Zotero.getString('browserAction_saveWebpageWithSnapshot', ZOTERO_CONFIG.CLIENT_NAME),
 			parentId: parentID,
 			contexts: ['page', ...buttonContext]
 		}));
 		fns.push(() => browser.contextMenus.create({
 			id: "zotero-context-menu-webpage-withoutSnapshot-save",
-			title: "Save to Zotero (Web Page without Snapshot)",
+			title: Zotero.getString('browserAction_saveWebpageWithoutSnapshot', ZOTERO_CONFIG.CLIENT_NAME),
 			parentId: parentID,
 			contexts: ['page', ...buttonContext]
 		}));
@@ -929,7 +930,7 @@ Zotero.Connector_Browser = new function() {
 	function _showPDFContextMenuItem(parentID) {
 		browser.contextMenus.create({
 			id: "zotero-context-menu-pdf-save",
-			title: "Save to Zotero (PDF)",
+			title: Zotero.getString('browserAction_savePDF', ZOTERO_CONFIG.CLIENT_NAME),
 			parentId: parentID,
 			contexts: ['all']
 		});
@@ -992,7 +993,7 @@ Zotero.Connector_Browser = new function() {
 		});
 		browser.contextMenus.create({
 			id: "zotero-context-menu-preferences",
-			title: "Preferences",
+			title: Zotero.getString('general_preferences'),
 			contexts: ['page', ...buttonContext]
 		});
 	}
@@ -1006,7 +1007,7 @@ Zotero.Connector_Browser = new function() {
 		});
 		browser.action.setTitle({
 			tabId: tab.id,
-			title: "Zotero Connector"
+			title: Zotero.getString('appConnector', ZOTERO_CONFIG.CLIENT_NAME)
 		});
 		browser.action.enable(tab.id);
 	}
@@ -1167,7 +1168,9 @@ Zotero.Connector_Browser = new function() {
 	
 	function _getTranslatorLabel(translator) {
 		var translatorName = translator.label;
-		return "Save to Zotero (" + translatorName + ")";
+		return Zotero.getString('browserAction_saveWithTranslator', [
+			ZOTERO_CONFIG.CLIENT_NAME, translatorName
+		]);
 	}
 	
 	Zotero.Messaging.addMessageListener("selectDone", function(data) {

--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -257,16 +257,16 @@ Zotero.Connector_Browser = new function() {
 	};
 	
 	/**
-	 * Called if Zotero version is determined to be incompatible with Standalone
+	 * Called if the Zotero Connector version is incompatible with the Zotero client
 	 */
-	this.onIncompatibleStandaloneVersion = function(zoteroVersion, standaloneVersion) {
-		if(_incompatibleVersionMessageShown) return;
-		alert('Zotero Connector for Chrome '+zoteroVersion+' is incompatible with the running '+
-			'version of Zotero Standalone'+(standaloneVersion ? " ("+standaloneVersion+")" : "")+
-			'. Zotero Connector will continue to operate, but functionality that relies upon '+
-			'Zotero Standalone may be unavailable.\n\n'+
-			'Please ensure that you have installed the latest version of these components. See '+
-			'https://www.zotero.org/download for more details.');
+	this.onIncompatibleStandaloneVersion = function(connectorVersion, clientVersion) {
+		if (_incompatibleVersionMessageShown) return;
+		alert('Zotero Connector ' + connectorVersion + ' is incompatible with the running '
+			+ 'version of the Zotero client' + (clientVersion ? " (" + clientVersion + ")" : "")
+			+ '. Zotero Connector will continue to operate, but functionality that relies upon '
+			+ 'the Zotero client may be unavailable.\n\n'
+			+ 'Please ensure that you have installed the latest version of these components. See '
+			+ 'https://www.zotero.org/download for more details.');
 		_incompatibleVersionMessageShown = true;
 	}
 

--- a/src/browserExt/confirm/confirm.js
+++ b/src/browserExt/confirm/confirm.js
@@ -1,4 +1,6 @@
 (async () => {
+	await Zotero.i18n.init();
+	document.title = Zotero.getString('confirmImport_title', ZOTERO_CONFIG.CLIENT_NAME);
 	Zotero.Messaging.init();
 	const isImport = window.location.hash.startsWith('#importCsl=') || window.location.hash.startsWith('#importContent=');
 	if (isImport) {

--- a/src/browserExt/contentTypeHandler.js
+++ b/src/browserExt/contentTypeHandler.js
@@ -181,7 +181,8 @@ Zotero.ContentTypeHandler = {
 
 	_shouldImportStyle: async function(tabId) {
 		if (!(await Zotero.Connector.checkIsOnline())) return false
-		let response = await Zotero.ContentTypeHandler.confirm(`Add citation style to Zotero?`, tabId)
+		let response = await Zotero.ContentTypeHandler.confirm(
+			Zotero.getString('contentTypeHandler_addStyle', ZOTERO_CONFIG.CLIENT_NAME), tabId)
 		return response && response.button === 1;
 	},
 
@@ -217,9 +218,9 @@ Zotero.ContentTypeHandler = {
 		if (isEnabledHost) {
 			return true;
 		} else {
-			let response = await Zotero.ContentTypeHandler.confirm(`Import items from ${URI.host} into Zotero?<br/><br/>` +
-				'You can manage automatic file importing in Zotero Connector preferences.', tabId,
-				'Always allow for this site')
+			let response = await Zotero.ContentTypeHandler.confirm(
+				Zotero.getString('contentTypeHandler_import', [ZOTERO_CONFIG.CLIENT_NAME, URI.host]), tabId,
+				Zotero.getString('contentTypeHandler_import_allow'))
 			if (response && response.button == 1) {
 				if (!isEnabledHost && response.checkboxChecked) {
 					hosts.push(URI.host);
@@ -324,13 +325,15 @@ Zotero.ContentTypeHandler = {
 			await Zotero.Connector_Browser.waitForTabToLoad(tab);
 		}
 		
-		var props = {message};
+		var props = {
+			title: Zotero.getString('appConnector', ZOTERO_CONFIG.CLIENT_NAME),
+			button1Text: Zotero.getString('general_ok'),
+			button2Text: Zotero.getString('general_cancel'),
+			message
+		};
 		if (checkboxText.length) {
-			props = {
-				message,
-				checkbox: true,
-				checkboxText
-			}
+			props.checkbox = true;
+			props.checkboxText = checkboxText;
 		}
 		return this._sendMessageAndHandleBlankPage('confirm', props, tab);
 	},
@@ -340,7 +343,7 @@ Zotero.ContentTypeHandler = {
 	 */
 	importFile: async function(url, tabId, type) {
 		var sessionID = Zotero.Utilities.randomString();
-		var headline = type == 'csl' ? 'Installing Style' : null;
+		var headline = type == 'csl' ? Zotero.getString('contentTypeHandler_installingStyle') : null;
 		var readOnly = type == 'csl';
 		var tab = await browser.tabs.get(tabId);
 		this._sendMessageAndHandleBlankPage('progressWindow.show', [sessionID, headline, readOnly], tab);

--- a/src/browserExt/manifest-v3.json
+++ b/src/browserExt/manifest-v3.json
@@ -2,7 +2,7 @@
 	"name": "Zotero Connector",
 	"manifest_version": 3,
 	"version": "AUTOFILLED",
-	"description": "Save references to Zotero from your web browser",
+	"description": "__MSG_extension_description__",
 	"default_locale": "en",
 	"action": {
 		"default_icon": {
@@ -10,7 +10,7 @@
 			"32": "images/treeitem-webpage-gray@2x.png",
 			"48": "images/treeitem-webpage-gray@48px.png"
 		},
-		"default_title": "Save to Zotero"
+		"default_title": "__MSG_extension_defaultTitle__"
 	},
 	"host_permissions": ["http://127.0.0.1/*", "https://repo.zotero.org/*", "https://api.zotero.org/*", "http://*/*", "https://*/*"],
 	"permissions": ["tabs", "contextMenus", "cookies", "scripting", "offscreen",

--- a/src/browserExt/manifest.json
+++ b/src/browserExt/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Zotero Connector",
 	"manifest_version": 2,
 	"version": "AUTOFILLED",
-	"description": "Save references to Zotero from your web browser",
+	"description": "__MSG_extension_description__",
 	"default_locale": "en",
 	"browser_action": {
 		"default_icon": {
@@ -10,7 +10,7 @@
 			"32": "images/treeitem-webpage-gray@2x.png",
 			"48": "images/treeitem-webpage-gray@48px.png"
 		},
-		"default_title": "Save to Zotero"
+		"default_title": "__MSG_extension_defaultTitle__"
 	},
 	"permissions": [
 		"http://127.0.0.1/*", "https://repo.zotero.org/*", "https://api.zotero.org/*", "http://*/*", "https://*/*",

--- a/src/browserExt/saveWithoutProgressWindow.js
+++ b/src/browserExt/saveWithoutProgressWindow.js
@@ -102,7 +102,7 @@ Zotero.Utilities.saveWithoutProgressWindow = async function (tab, frameId) {
 		});
 		browser.browserAction.setTitle({
 			tabId:tab.id,
-			title: "Saving…"
+			title: Zotero.getString('browserAction_saving')
 		});
 		
 		try {
@@ -125,7 +125,7 @@ Zotero.Utilities.saveWithoutProgressWindow = async function (tab, frameId) {
 		});
 		browser.browserAction.setTitle({
 			tabId:tab.id,
-			title: "Saved!"
+			title: Zotero.getString('browserAction_saved')
 		});
 		tabInfo.isPDF = false;
 	
@@ -141,7 +141,7 @@ Zotero.Utilities.saveWithoutProgressWindow = async function (tab, frameId) {
 		
 		browser.browserAction.setTitle({
 			tabId:tab.id,
-			title: "Saving failed. Is Zotero running?"
+			title: Zotero.getString('browserAction_saveFailed', ZOTERO_CONFIG.CLIENT_NAME)
 		});
 	}
 }

--- a/src/common/i18n_common.js
+++ b/src/common/i18n_common.js
@@ -26,8 +26,10 @@
 Zotero.i18n.translateFragment = function (elem) {
 	let elems = elem.querySelectorAll('[data-l10n-id]')
 	for (let elem of elems) {
-		let str = Zotero.getString(elem.dataset.l10nId);
-		if (elem.nodeName === 'INPUT' && elem.type === "submit") {
+		let substitutions = elem.dataset.l10nClientName === undefined
+			? undefined : ZOTERO_CONFIG.CLIENT_NAME;
+		let str = Zotero.getString(elem.dataset.l10nId, substitutions);
+		if (elem.nodeName === 'INPUT' && ["button", "submit"].includes(elem.type)) {
 			elem.value = str;
 		}
 		else if (elem.nodeName === 'INPUT' && elem.type === "text") {

--- a/src/common/inject/inject.jsx
+++ b/src/common/inject/inject.jsx
@@ -265,10 +265,10 @@ Zotero.Inject = {
 	
 	async expiredBetaBuildPrompt() {
 		return this.confirm({
-			title: "Build Expired",
-			button1Text: "OK",
+			title: Zotero.getString('expiredBetaBuild_title'),
+			button1Text: Zotero.getString('general_ok'),
 			button2Text: "",
-			message: `This Zotero Connector beta build has expired. Please download the latest version from zotero.org.`
+			message: Zotero.getString('expiredBetaBuild_message', ZOTERO_CONFIG.CLIENT_NAME)
 		});
 	},
 

--- a/src/common/inject/pageSaving.js
+++ b/src/common/inject/pageSaving.js
@@ -280,7 +280,7 @@ let PageSaving = {
 			var { items, proxy } = await Zotero.TranslateWeb.translate(options);
 		} catch (e) {
 			if (translators[0].itemType != 'multiple' && fallbackOnFailure) {
-				Zotero.Messaging.sendMessage("progressWindow.error", ['fallback', this.translators.at(-1).label, "Save as Webpage"]);
+				Zotero.Messaging.sendMessage("progressWindow.error", ['fallback', this.translators.at(-1).label, Zotero.getString('progressWindow_saveAsWebpage')]);
 				Zotero.debug(`Saving with ${translators[0].label} failed. Falling back to saving as webpage`);
 				return this.saveAsWebpage({ snapshot: true });
 			}
@@ -397,7 +397,7 @@ let PageSaving = {
 				sessionID: data.sessionID,
 				id: 2,
 				iconSrc: Zotero.ItemTypes.getImageSrc("attachment-snapshot"),
-				title: "Snapshot",
+				title: Zotero.getString('itemType_snapshot'),
 				parentItem: 1,
 				parentKey: item.key,
 				progress: 0,

--- a/src/common/inject/progressWindow_inject.js
+++ b/src/common/inject/progressWindow_inject.js
@@ -103,7 +103,7 @@ if (isTopWindow) {
 		}
 		catch (e) {
 			// TODO: Shouldn't this be coupled to the actual save process?
-			changeHeadline("Saving to zotero.org");
+			changeHeadline(Zotero.getString('progressWindow_savingToOnlineLibrary'));
 			return;
 		}
 		

--- a/src/common/itemSelector/itemSelector.html
+++ b/src/common/itemSelector/itemSelector.html
@@ -20,7 +20,7 @@
 		<meta charset="UTF-8">
 		<meta name="google" content="notranslate">
 		<link rel="stylesheet" type="text/css" media="screen" href="itemSelector.css" />
-		<title>Zotero Item Selector</title>
+		<title data-l10n-id="itemSelector_windowTitle" data-l10n-client-name>Zotero Item Selector</title>
 	</head>
 	<body>
 		<div id="label" data-l10n-id="itemSelector_title">Select which items you'd like to add to your library:</div>

--- a/src/common/preferences/preferences.css
+++ b/src/common/preferences/preferences.css
@@ -80,6 +80,7 @@ body {
 }
 
 .group-title {
+	display: block;
 	font-size: 14px;
 	margin-bottom: 10px;
 }

--- a/src/common/preferences/preferences.html
+++ b/src/common/preferences/preferences.html
@@ -20,49 +20,49 @@
 	<head>
 		<meta charset="UTF-8">
 		<link rel="stylesheet" type="text/css" media="screen" href="preferences.css" />
-		<title>Zotero Connector Preferences</title>
+		<title data-l10n-id="preferences_title" data-l10n-client-name>Zotero Connector Preferences</title>
 	</head>
 	<body>
 		<div id="panes">
 			<div id="pane-general" class="pane">
 				<div class="pane-image"><img src="../images/prefs-general.png" alt=""/></div>
-				<a href="#general" class="pane-label">General</a>
+				<a href="#general" class="pane-label" data-l10n-id="preferences_general">General</a>
 			</div>
 			<div id="pane-proxies" class="pane" style="display: none">
 				<div class="pane-image"><img src="../images/prefs-proxies.png" alt=""/></div>
-				<a href="#proxies" class="pane-label">Proxies</a>
+				<a href="#proxies" class="pane-label" data-l10n-id="preferences_proxies">Proxies</a>
 			</div>
 			<div id="pane-advanced" class="pane">
 				<div class="pane-image"><img src="../images/prefs-advanced.png" alt=""/></div>
-				<a href="#advanced" class="pane-label">Advanced</a>
+				<a href="#advanced" class="pane-label" data-l10n-id="preferences_advanced">Advanced</a>
 			</div>
 		</div>
 		<div id="content-general" class="content">
 			<div class="group">
-				<div class="group-title">Zotero Status</div>
+				<div class="group-title" data-l10n-id="preferences_zoteroStatus" data-l10n-client-name>Zotero Status</div>
 				<div class="group-content" id="client-status"></div>
 			</div>
 			<div class="group">
-				<div class="group-title">Save to Zotero.org</div>
+				<div class="group-title" data-l10n-id="preferences_saveToOnlineLibrary">Save to Zotero.org</div>
 				<div class="group-content">
 					<div id="general-authorization-not-authorized">
-						<p>Zotero Connector is not currently authorized to save items to zotero.org. You will be prompted for authorization if you try to save items while Zotero is not open.</p>
+						<p data-l10n-id="preferences_onlineLibrary_notAuthorized" data-l10n-client-name>Zotero Connector is not currently authorized to save items to zotero.org. You will be prompted for authorization if you try to save items while Zotero is not open.</p>
 					</div>
 					<div id="general-authorization-authorized" style="display:none">
-						<p>Zotero Connector will save items to zotero.org as <span id="general-span-authorization-username"></span> when Zotero is not open.</p>
+						<p id="general-authorization-authorized-message"></p>
 						<p>
-							<input type="button" value="Clear Credentials" id="general-button-clear-credentials"/>
+							<input type="button" value="Clear Credentials" id="general-button-clear-credentials" data-l10n-id="preferences_onlineLibrary_clearCredentials"/>
 						</p>
 						<p>
-							<label><input type="checkbox" data-pref="automaticSnapshots"/>&nbsp;Automatically take snapshots when saving items</label>
-							<label><input type="checkbox" data-pref="downloadAssociatedFiles"/>&nbsp;Automatically download associated PDFs and other files when saving items</label>
-							<label><input type="checkbox" data-pref="automaticTags"/>&nbsp;Automatically tag items with keywords and subject headings</label>
+							<label><input type="checkbox" data-pref="automaticSnapshots"/>&nbsp;<span data-l10n-id="preferences_onlineLibrary_automaticSnapshots">Automatically take snapshots when saving items</span></label>
+							<label><input type="checkbox" data-pref="downloadAssociatedFiles"/>&nbsp;<span data-l10n-id="preferences_onlineLibrary_downloadAssociatedFiles">Automatically download associated PDFs and other files when saving items</span></label>
+							<label><input type="checkbox" data-pref="automaticTags"/>&nbsp;<span data-l10n-id="preferences_onlineLibrary_automaticTags">Automatically tag items with keywords and subject headings</span></label>
 						</p>
 					</div>
 				</div>
 			</div>
 			<div class="group" style="display: none" id="intercept-and-import">
-				<div class="group-title">Automatic File Importing</div>
+				<div class="group-title" data-l10n-id="preferences_fileImporting">Automatic File Importing</div>
 				<!-- React Component -->
 				<div class="group-content"></div>
 			</div>
@@ -71,43 +71,43 @@
 		<div id="content-proxies" class="content"></div>
 		<div id="content-advanced" class="content">
 			<div class="group">
-				<div class="group-title">Report Errors</div>
+				<div class="group-title" data-l10n-id="preferences_reportErrors">Report Errors</div>
 				<div class="group-content">
 					<div id="advanced-no-errors">
-						No errors have been logged.
+						<span data-l10n-id="preferences_reportErrors_none">No errors have been logged.</span>
 					</div>
 					<div id="advanced-have-errors" style="display:none">
-						<p>The following errors have occurred since the Zotero Connector was started:</p>
+						<p data-l10n-id="preferences_reportErrors_subtitle" data-l10n-client-name>The following errors have occurred since the Zotero Connector was started:</p>
 						<p><textarea id="advanced-textarea-errors" style="width:100%; height:10em;" readonly="true"></textarea></p>
 					</div>
-					<p><input type="button" id="advanced-button-report-errors" value="Submit Report"/></p>
+					<p><input type="button" id="advanced-button-report-errors" value="Submit Report" data-l10n-id="preferences_reportErrors_submit"/></p>
 				</div>
 			</div>
 			<div class="group">
-				<div class="group-title">Debug Output Logging</div>
+				<div class="group-title" data-l10n-id="preferences_debugOutput">Debug Output Logging</div>
 				<div class="group-content">
-					<p>Debug output can help Zotero developers diagnose problems. Debug logging may slow down your browser, so you should generally leave it disabled unless a Zotero developer requests debug output.</p>
+					<p data-l10n-id="preferences_debugOutput_description" data-l10n-client-name>Debug output can help Zotero developers diagnose problems. Debug logging may slow down your browser, so you should generally leave it disabled unless a Zotero developer requests debug output.</p>
 					<p>
-						<label><input type="checkbox" id="advanced-checkbox-enable-logging"/>&nbsp;Enable Logging</label>
-						<label><input type="checkbox" id="advanced-checkbox-enable-at-startup"/>&nbsp;Enable at Startup</label>
+						<label><input type="checkbox" id="advanced-checkbox-enable-logging"/>&nbsp;<span data-l10n-id="preferences_debugOutput_enable">Enable Logging</span></label>
+						<label><input type="checkbox" id="advanced-checkbox-enable-at-startup"/>&nbsp;<span data-l10n-id="preferences_debugOutput_enableAtStartup">Enable at Startup</span></label>
 					</p>
 					<p>
-						<span id="advanced-span-lines-logged"></span> lines logged
+						<span id="advanced-span-lines-logged">0 lines logged</span>
 					</p>
 					<p>
-						<input type="button" id="advanced-button-view-output" value="View Output"/>
-						<input type="button" id="advanced-button-clear-output" value="Clear Output"/>
-						<input type="button" id="advanced-button-submit-output" value="Submit Output"/>
+						<input type="button" id="advanced-button-view-output" value="View Output" data-l10n-id="preferences_debugOutput_view"/>
+						<input type="button" id="advanced-button-clear-output" value="Clear Output" data-l10n-id="preferences_debugOutput_clear"/>
+						<input type="button" id="advanced-button-submit-output" value="Submit Output" data-l10n-id="preferences_debugOutput_submit"/>
 					</p>
 					<p><textarea id="advanced-textarea-debug" style="width:100%; height:10em; display:none" readonly="true"></textarea></p>
 				</div>
 			</div>
 			<div class="group">
-				<div class="group-title">Translators</div>
+				<div class="group-title" data-l10n-id="preferences_translators">Translators</div>
 				<div class="group-content">
-					<label><input type="checkbox" id="advanced-checkbox-report-translator-failure"/> Report broken site translators to zotero.org</label>
+					<label><input type="checkbox" id="advanced-checkbox-report-translator-failure"/> <span data-l10n-id="preferences_translators_reportErrors">Report broken site translators to zotero.org</span></label>
 					<p>
-						<input type="button" id="advanced-button-reset-translators" value="Reset Translators" title="Reset Translators"/>
+						<input type="button" id="advanced-button-reset-translators" value="Reset Translators" data-l10n-id="preferences_translators_reset"/>
 						<!--BEGIN DEBUG-->
 						<input type="button" id="advanced-button-open-translator-tester" value="Open Translator Tester"/>
 						<!--END DEBUG-->
@@ -115,15 +115,15 @@
 				</div>
 			</div>
 			<div class="group" id="advanced-group-google-docs">
-				<div class="group-title">Google Docs Integration</div>
+				<div class="group-title" data-l10n-id="preferences_googleDocs">Google Docs Integration</div>
 				<div class="group-content">
 					<div id="google-docs-pref">
 						<p>
-							<label><input id="advanced-checkbox-google-docs-enabled" type="checkbox" data-pref="integration.googleDocs.enabled"/>Enable Google Docs Integration</label>
+							<label><input id="advanced-checkbox-google-docs-enabled" type="checkbox" data-pref="integration.googleDocs.enabled"/><span data-l10n-id="preferences_googleDocs_enable">Enable Google Docs Integration</span></label>
 						</p>
 						<div id="advanced-google-docs-subprefs" style="margin-left: 1em">
 <!--							<label style="margin-top: -7px; margin-bottom: 5px"><input type="checkbox" data-pref="integration.googleDocs.useGoogleDocsAPI"/>Enable Google Docs Integration v2 (NEW)</label>-->
-							<label>Add/Edit Citation Shortcut<input is="shortcut-input" type="text" class="shortcut-input" data-pref="shortcuts.cite"></label>
+							<label><span data-l10n-id="preferences_googleDocs_shortcut">Add/Edit Citation Shortcut</span><input is="shortcut-input" type="text" class="shortcut-input" data-pref="shortcuts.cite"></label>
 						</div>
 					</div>
 				</div>
@@ -160,6 +160,7 @@
 		<script type="text/javascript" src="../zoteroFrame.js"></script>
 		<script type="text/javascript" src="../inject/modalPrompt_inject.js"></script>
 		<script type="text/javascript" src="../i18n.js"></script>
+		<script type="text/javascript" src="../i18n_common.js"></script>
 		<script type="text/javascript" src="preferences.js"></script>
 		<!--BEGIN DEBUG-->
 		<script type="text/javascript" src="../lib/sinon.js"></script>

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -47,6 +47,7 @@ var Zotero_Preferences = {
 		Zotero.Messaging.init();
 		Zotero.Messaging.addMessageListener('confirm', props => Zotero.ModalPrompt.confirm(props));
 		await Zotero.i18n.init();
+		Zotero.i18n.translateFragment(document);
 
 		await Zotero.Prefs.loadNamespace(['interceptKnownFileTypes', 'allowedInterceptHosts']);
 		
@@ -151,7 +152,8 @@ var Zotero_Preferences = {
 			// get debug logging info
 			return Zotero.Connector_Debug.count();
 		}).then(function(count) {
-			document.getElementById('advanced-span-lines-logged').textContent = count.toString();
+			document.getElementById('advanced-span-lines-logged').textContent
+				= Zotero.getString('preferences_debugOutput_linesLogged', count);
 			toggleDisabled(document.getElementById('advanced-button-view-output'), !count);
 			toggleDisabled(document.getElementById('advanced-button-clear-output'), !count);
 			toggleDisabled(document.getElementById('advanced-button-submit-output'), !count);
@@ -182,7 +184,10 @@ Zotero_Preferences.General = {
 		document.getElementById('general-authorization-not-authorized').style.display = (userInfo ? 'none' : 'block');
 		document.getElementById('general-authorization-authorized').style.display = (!userInfo ? 'none' : 'block');
 		if(userInfo) {
-			document.getElementById('general-span-authorization-username').textContent = userInfo.username;
+			document.getElementById('general-authorization-authorized-message').textContent
+					= Zotero.getString('preferences_onlineLibrary_authorized', [
+						ZOTERO_CONFIG.CLIENT_NAME, userInfo.username
+					]);
 		}
 	},
 
@@ -224,16 +229,16 @@ Zotero_Preferences.Advanced = {
 		document.getElementById("advanced-button-clear-output").onclick = Zotero_Preferences.Advanced.clearDebugOutput;
 		document.getElementById("advanced-button-submit-output").onclick = Zotero_Preferences.Advanced.submitDebugOutput;
 		document.getElementById("advanced-button-reset-translators").addEventListener('click', async (event) => { 
-			event.target.value = "Resetting translators…";
+			event.target.value = Zotero.getString('preferences_translators_resetting');
 			try {
 				// Otherwise "Resetting translators..." flash-appears and it looks glitchy
 				await Promise.all([Zotero.Promise.delay(1000), (async () => {
 					await Zotero.Prefs.removeAllCachedTranslators();
 					return Zotero.Translators.updateFromRemote(true)
 				})()]);
-				event.target.value = "Translators updated!";
+				event.target.value = Zotero.getString('preferences_translators_updated');
 			} catch (e) {
-				event.target.value = "Translator update failed";
+				event.target.value = Zotero.getString('preferences_translators_updateFailed');
 			}
 		});
 		document.getElementById("advanced-button-report-errors").onclick = Zotero_Preferences.Advanced.submitErrors;
@@ -315,7 +320,7 @@ Zotero_Preferences.Advanced = {
 			let reportID = await Zotero.Connector_Debug.submitReport();
 			let result = await Zotero.ModalPrompt.confirm({
 				message: Zotero.getString('reports_debug_output_submitted', 'D' + reportID).replace(/\n/g, '<br/>'),
-				button1Text: "OK",
+				button1Text: Zotero.getString('general_ok'),
 				button2Text: !Zotero.isSafari ? Zotero.getString("general_copyToClipboard") : "",
 			});
 			if (result.button == 2) {
@@ -350,7 +355,7 @@ Zotero_Preferences.Advanced = {
 			var reportID = await Zotero.Errors.sendErrorReport();
 			let result = await Zotero.ModalPrompt.confirm({
 				message: Zotero.getString('reports_report_submitted', reportID).replace(/\n/g, '<br/>'),
-				button1Text: "OK",
+				button1Text: Zotero.getString('general_ok'),
 				button2Text: !Zotero.isSafari ? Zotero.getString("general_copyToClipboard") : "",
 			});
 			if (result.button == 2) {
@@ -390,13 +395,14 @@ Zotero_Preferences.Components.ClientStatus = class ClientStatus extends React.Co
 	}
 	
 	render() {
-		let available = <span>available.</span>;
-		if (!this.state.available) {
-			available = <span>unavailable. If Zotero is open, see the <a href="https://www.zotero.org/support/kb/connector_zotero_unavailable">troubleshooting page</a>.</span>
-		}
+		let status = this.state.available
+			? Zotero.getString('preferences_zoteroStatus_available', ZOTERO_CONFIG.CLIENT_NAME)
+			: Zotero.getString('preferences_zoteroStatus_unavailable',
+				[ZOTERO_CONFIG.CLIENT_NAME,
+					'https://www.zotero.org/support/kb/connector_zotero_unavailable']);
 		return (<div>
-			<p>Zotero is currently {available}</p>
-			<p><input type="button" value="Update Status" onClick={this.checkStatus}/></p>
+			<p dangerouslySetInnerHTML={{__html: status}}/>
+			<p><input type="button" value={Zotero.getString('preferences_zoteroStatus_update')} onClick={this.checkStatus}/></p>
 		</div>)
 	}
 };
@@ -420,14 +426,18 @@ Zotero_Preferences.Components.ProxySettings = class ProxySettings extends React.
 		return (
 			<div>
 				<div className="group">
-					<div className="group-title">Proxy Settings</div>
+					<div className="group-title">{Zotero.getString('preferences_proxySettings')}</div>
 					<div className="group-content">
-						<p>Zotero will transparently redirect requests through saved proxies. See the <a href="https://www.zotero.org/support/connector_preferences#proxies">proxy documentation</a> for more information.</p>
+						<p dangerouslySetInnerHTML={{__html: Zotero.getString(
+							'preferences_proxySettings_description',
+							[ZOTERO_CONFIG.CLIENT_NAME,
+								'https://www.zotero.org/support/connector_preferences#proxies'])
+						}}/>
 						<Zotero_Preferences.Components.ProxyPreferences onTransparentChange={this.handleTransparentChange}/>
 					</div>
 				</div>
 				<div className="group">
-					<div className="group-title">Configured Proxies</div>
+					<div className="group-title">{Zotero.getString('preferences_proxySettings_configured')}</div>
 					<div className="group-content">
 						<Zotero_Preferences.Components.Proxies transparent={this.state.transparent}/>
 					</div>
@@ -479,12 +489,12 @@ Zotero_Preferences.Components.ProxyPreferences = class ProxyPreferences extends 
 	}
 	
 	render() {
-		let autoRecognise = <label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="autoRecognize" defaultChecked={this.state.autoRecognize}/>&nbsp;Automatically detect new proxies</label>;
+		let autoRecognise = <label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="autoRecognize" defaultChecked={this.state.autoRecognize}/>&nbsp;{Zotero.getString('preferences_proxySettings_autoRecognize')}</label>;
 		let redirectLoopPrevention = ''
 		if (this.state.loopPreventionTimestamp > Date.now() && this.state.transparent) {
 			redirectLoopPrevention = (
 				<div className="group">
-					<b>Zotero detected a proxy redirect loop and has temporarily suspended automatic proxy redirection.</b> <input type="button" onClick={this.reenableProxyRedirection} value="Re-enable proxy redirection"/>
+					<b>{Zotero.getString('preferences_proxySettings_redirectLoop', ZOTERO_CONFIG.CLIENT_NAME)}</b> <input type="button" onClick={this.reenableProxyRedirection} value={Zotero.getString('preferences_proxySettings_reenable')}/>
 				</div>
 			)
 		}
@@ -492,13 +502,13 @@ Zotero_Preferences.Components.ProxyPreferences = class ProxyPreferences extends 
 			<div>
 				{redirectLoopPrevention}
 				<div>
-					<label><input type="checkbox" name="transparent" onChange={this.handleCheckboxChange} defaultChecked={this.state.transparent}/>&nbsp;Enable proxy redirection</label>
+					<label><input type="checkbox" name="transparent" onChange={this.handleCheckboxChange} defaultChecked={this.state.transparent}/>&nbsp;{Zotero.getString('preferences_proxySettings_enable')}</label>
 					<div style={{marginLeft: "1em"}}>
-						<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="showRedirectNotification" defaultChecked={this.state.showRedirectNotification}/>&nbsp;Show a notification when redirecting through a proxy</label>
+						<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="showRedirectNotification" defaultChecked={this.state.showRedirectNotification}/>&nbsp;{Zotero.getString('preferences_proxySettings_showRedirectNotification')}</label>
 						<br/>
 						{autoRecognise}
 						<p>
-							<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="disableByDomain" defaultChecked={this.state.disableByDomain}/>&nbsp;Disable proxy redirection when my domain name contains (available when Zotero is running)</label>
+							<label><input type="checkbox" disabled={!this.state.transparent} onChange={this.handleCheckboxChange} name="disableByDomain" defaultChecked={this.state.disableByDomain}/>&nbsp;{Zotero.getString('preferences_proxySettings_disableByDomain', ZOTERO_CONFIG.CLIENT_NAME)}</label>
 							<br/>
 							<input style={{marginTop: "0.5em", marginLeft: "1.5em"}} type="text" onChange={this.handleTextInputChange} disabled={!this.state.transparent || !this.state.disableByDomain} name="disableByDomainString" defaultValue={this.state.disableByDomainString}/>
 						</p>
@@ -663,9 +673,9 @@ Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
 	function _renderProxyInput() {
 		return (
 			<div className="proxy-grid">
-				<label htmlFor="to-proxy-scheme-input">Login URL Scheme:</label>
+				<label htmlFor="to-proxy-scheme-input">{Zotero.getString('preferences_proxySettings_loginURLScheme')}</label>
 				<input id="to-proxy-scheme-input" style={{flexGrow: "1"}} type="text" name="toProxyScheme" onChange={handleSchemeChange} value={toProxyScheme || ""} ref={toProxyInputRef}/>
-				<label htmlFor="to-proper-scheme-input">Proxied URL Scheme:</label>
+				<label htmlFor="to-proper-scheme-input">{Zotero.getString('preferences_proxySettings_proxiedURLScheme')}</label>
 				<input id="to-proper-scheme-input" style={{flexGrow: "1"}} type="text" name="toProperScheme" onChange={handleSchemeChange} value={toProperScheme || ""}/>
 			</div>
 		)
@@ -674,7 +684,7 @@ Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
 	function _renderOpenAthensInput() {
 		return (
 			<div className="proxy-grid">
-				<label htmlFor="openathens-domain-input">OpenAthens Redirector Domain:</label>
+				<label htmlFor="openathens-domain-input">{Zotero.getString('preferences_proxySettings_openAthensDomain')}</label>
 				<input id="openathens-domain-input" style={{flexGrow: "1"}} type="text" name="openathensDomain" onChange={handleOpenAthensDomainChange} value={getOpenAthensDomain() || ""} placeholder="yourinstitution.ac.uk"/>
 			</div>
 		)
@@ -683,13 +693,13 @@ Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
 	return (
 		<div className="group" style={{marginTop: "10px"}}>
 			<p>
-				<label><input type="radio" name="proxyType" value="ezproxy" checked={!isOpenAthens} onChange={handleTypeChange}/>URL-rewriting proxy (e.g., EZproxy)</label>
-				<label><input type="radio" name="proxyType" value="openathens" checked={isOpenAthens} onChange={handleTypeChange}/>OpenAthens</label>
+				<label><input type="radio" name="proxyType" value="ezproxy" checked={!isOpenAthens} onChange={handleTypeChange}/>{Zotero.getString('preferences_proxySettings_urlRewritingProxy')}</label>
+				<label><input type="radio" name="proxyType" value="openathens" checked={isOpenAthens} onChange={handleTypeChange}/>{Zotero.getString('preferences_proxySettings_openAthens')}</label>
 			</p>
 
 			{multiHost && !isOpenAthens &&
 				<p>
-					<label><input type="checkbox" name="autoAssociate" onChange={handleCheckboxChange} checked={autoAssociate}/>&nbsp;Automatically associate new hosts</label>
+					<label><input type="checkbox" name="autoAssociate" onChange={handleCheckboxChange} checked={autoAssociate}/>&nbsp;{Zotero.getString('preferences_proxySettings_autoAssociate')}</label>
 				</p>
 			}
 			{isOpenAthens ? _renderOpenAthensInput() : _renderProxyInput()}
@@ -698,15 +708,15 @@ Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
 
 			{!isOpenAthens &&
 				<p>
-					You may use the following variables in your proxy schemes:<br/>
-					&#37;h - The hostname of the proxied site (e.g., www.example.com)<br/>
-					&#37;p - The path of the proxied page excluding the leading slash (e.g., about/index.html)<br/>
-					&#37;u - Full encoded proxied site url (e.g. https://www.example.com/about/index.html)
+					{Zotero.getString('preferences_proxySettings_variables')}<br/>
+					{Zotero.getString('preferences_proxySettings_variableHost')}<br/>
+					{Zotero.getString('preferences_proxySettings_variablePath')}<br/>
+					{Zotero.getString('preferences_proxySettings_variableURL')}
 				</p>
 			}
 			
 			<div style={{display: "flex", flexDirection: "column", marginTop: "10px"}}>
-				<label>Hostnames</label>
+				<label>{Zotero.getString('preferences_proxySettings_hostnames')}</label>
 				<select className="Preferences-Proxies-hostSelect" size="8" multiple
 						value={[currentHostIdx != -1 ? currentHostIdx : '']}
 						onChange={handleHostSelectChange}>
@@ -714,12 +724,12 @@ Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
 						<option key={i} value={i}>{host}</option>)}
 				</select>
 				<p>
-					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleAddHost} value="+"/>
-					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleRemoveHost} disabled={disableRemoveHost} value="-"/>
+					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleAddHost} value="+" aria-label={Zotero.getString('preferences_proxySettings_addHostname')}/>
+					<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleRemoveHost} disabled={disableRemoveHost} value="-" aria-label={Zotero.getString('preferences_proxySettings_removeHostname')}/>
 				</p>
 				
 				<p style={{display: currentHostIdx === -1 ? 'none' : 'flex'}}>
-					<label>Hostname:
+					<label>{Zotero.getString('preferences_proxySettings_hostname')}
 						<input style={{flexGrow: '1'}}
 							type="text"
 							value={hosts[currentHostIdx] || ""}
@@ -782,8 +792,8 @@ Zotero_Preferences.Components.Proxies = function Proxies(props) {
 				})}
 			</select>
 			<p style={{display: props.transparent ? null : 'none'}}>
-				<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleProxyAdd} value="+"/>
-				<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleProxyRemove} disabled={!canRemoveProxy} value="-"/>
+				<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleProxyAdd} value="+" aria-label={Zotero.getString('preferences_proxySettings_addProxy')}/>
+				<input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={handleProxyRemove} disabled={!canRemoveProxy} value="-" aria-label={Zotero.getString('preferences_proxySettings_removeProxy')}/>
 			</p>
 			
 			<Zotero_Preferences.Components.ProxyDetails
@@ -866,7 +876,7 @@ Zotero_Preferences.Components.MIMETypeHandling = class MIMETypeHandling extends 
 		let hostname = '';
 		if (this.state.currentHostIdx != -1) {
 			hostname = <p style={{display: this.state.currentHostIdx === -1 ? 'none' : 'flex'}}>
-				<label style={{alignSelf: 'center'}}>Hostname: </label>
+				<label style={{alignSelf: 'center'}}>{Zotero.getString('preferences_proxySettings_hostname')} </label>
 				<input style={{flexGrow: '1'}} type="text" defaultValue={this.state.hosts[this.state.currentHostIdx] || ''} onChange={this.handleHostnameChange}/>
 			</p>
 		}
@@ -875,18 +885,18 @@ Zotero_Preferences.Components.MIMETypeHandling = class MIMETypeHandling extends 
 		
 		return (
 			<div>
-				<p>Available when Zotero is running</p>
+				<p>{Zotero.getString('preferences_fileImporting_clientRequired', ZOTERO_CONFIG.CLIENT_NAME)}</p>
 				<p>
-					<label><input type="checkbox" onChange={this.handleCheckboxChange} name="enabled" defaultChecked={this.state.enabled}/>&nbsp;Import BibTeX/RIS/Refer files into Zotero</label>
+					<label><input type="checkbox" onChange={this.handleCheckboxChange} name="enabled" defaultChecked={this.state.enabled}/>&nbsp;{Zotero.getString('preferences_fileImporting_enable', ZOTERO_CONFIG.CLIENT_NAME)}</label>
 				</p>
 				<div style={{display: this.state.enabled ? 'flex' : 'none', flexDirection: "column", marginTop: "10px"}}>
-					<label>Enabled Hostnames</label>
+					<label>{Zotero.getString('preferences_fileImporting_hostnames')}</label>
 					<select className="Preferences-MIMETypeHandling-hostSelect" size="8" multiple
 							value={this.state.currentHostIdx}
 							onChange={this.handleSelectChange}>
 						{hosts}
 					</select>
-					<p> <input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={this.handleHostRemove} disabled={disabled} value="Remove"/> </p>
+					<p> <input style={{minWidth: "80px", marginRight: "10px"}} type="button" onClick={this.handleHostRemove} disabled={disabled} value={Zotero.getString('preferences_fileImporting_remove')}/> </p>
 					{hostname}
 				</div>
 

--- a/src/common/preferences/preferences.jsx
+++ b/src/common/preferences/preferences.jsx
@@ -437,7 +437,7 @@ Zotero_Preferences.Components.ProxySettings = class ProxySettings extends React.
 					</div>
 				</div>
 				<div className="group">
-					<div className="group-title">{Zotero.getString('preferences_proxySettings_configured')}</div>
+					<label className="group-title" htmlFor="proxies-proxy-select">{Zotero.getString('preferences_proxySettings_configured')}</label>
 					<div className="group-content">
 						<Zotero_Preferences.Components.Proxies transparent={this.state.transparent}/>
 					</div>
@@ -716,8 +716,8 @@ Zotero_Preferences.Components.ProxyDetails = function ProxyDetails(props) {
 			}
 			
 			<div style={{display: "flex", flexDirection: "column", marginTop: "10px"}}>
-				<label>{Zotero.getString('preferences_proxySettings_hostnames')}</label>
-				<select className="Preferences-Proxies-hostSelect" size="8" multiple
+				<label htmlFor="proxies-host-select">{Zotero.getString('preferences_proxySettings_hostnames')}</label>
+				<select id="proxies-host-select" className="Preferences-Proxies-hostSelect" size="8" multiple
 						value={[currentHostIdx != -1 ? currentHostIdx : '']}
 						onChange={handleHostSelectChange}>
 					{hosts.map((host, i) =>
@@ -783,7 +783,7 @@ Zotero_Preferences.Components.Proxies = function Proxies(props) {
 
 	return (
 		<div style={{display: "flex", flexDirection: "column"}}>
-			<select className="Preferences-Proxies-proxySelect" size="8" multiple
+			<select id="proxies-proxy-select" className="Preferences-Proxies-proxySelect" size="8" multiple
 					value={[canRemoveProxy ? proxies[currentProxyIdx].id : '']}
 					onChange={handleProxySelectChange}
 					disabled={!props.transparent}>

--- a/src/common/proxy.js
+++ b/src/common/proxy.js
@@ -240,20 +240,20 @@ Zotero.Proxies = new function() {
 	
 	this.notifyNewProxy = async function(proxy, tabId) {
 		let instance = Zotero.Proxies._createProxyInstance(proxy);
+		let host = proxy.hosts[proxy.hosts.length - 1];
+		let proxyName = instance.toDisplayName();
 		let response = await Zotero.Proxies.showNotification(
-			'New Zotero Proxy',
-			`Zotero detected that you are accessing ${proxy.hosts[proxy.hosts.length-1]} through a proxy. Would you like to automatically redirect future requests to ${proxy.hosts[proxy.hosts.length-1]} through ${instance.toDisplayName()}?`,
-			['✕', 'Proxy Settings', 'Accept'],
+			Zotero.getString('proxy_newProxy_title'),
+			Zotero.getString('proxy_newProxy_message', [ZOTERO_CONFIG.CLIENT_NAME, host, proxyName]),
+			['✕', Zotero.getString('proxy_settings'), Zotero.getString('proxy_accept')],
 			tabId
 		);
 		if (response == 2) {
 			let result = await Zotero.Messaging.sendMessage('confirm', {
-				title: 'Only add proxies linked from your library, school, or corporate website',
-				message: 'Adding other proxies allows malicious sites to masquerade as sites you trust.<br/></br>'
-				+ 'Adding this proxy will allow Zotero to recognize items from proxied pages and will automatically '
-				+ `redirect future requests to ${proxy.hosts[proxy.hosts.length - 1]} through ${instance.toDisplayName()}.`,
-				button1Text: 'Add Proxy',
-				button2Text: 'Cancel'
+				title: Zotero.getString('proxy_addProxy_title'),
+				message: Zotero.getString('proxy_addProxy_message', [ZOTERO_CONFIG.CLIENT_NAME, host, proxyName]),
+				button1Text: Zotero.getString('proxy_addProxy'),
+				button2Text: Zotero.getString('general_cancel')
 			}, tabId);
 			if (result.button == 1) {
 				return Zotero.Proxies.save(proxy);
@@ -828,9 +828,9 @@ Zotero.Proxy = class {
 		Zotero.Proxies.toggleRedirectLoopPrevention(false);
 
 		Zotero.Proxies.showNotification(
-			'New Zotero Proxy Host',
-			`Zotero automatically associated ${host} with a previously defined proxy. Future requests to this site will be redirected through ${this.toDisplayName()}.`,
-			["✕", "Proxy Settings", "Don’t Proxy This Site"],
+			Zotero.getString('proxy_newHost_title'),
+			Zotero.getString('proxy_newHost_message', [ZOTERO_CONFIG.CLIENT_NAME, host, this.toDisplayName()]),
+			["✕", Zotero.getString('proxy_settings'), Zotero.getString('proxy_dontProxy')],
 			details.tabId
 		)
 		.then((response) => {
@@ -869,9 +869,9 @@ Zotero.Proxy = class {
 		// Otherwise, redirect.
 		if (Zotero.Proxies.showRedirectNotification && details.frameId === 0) {
 			Zotero.Proxies.showNotification(
-				'Zotero Proxy Redirection',
-				`Zotero automatically redirected your request to ${uri.host} through the proxy at ${this.toDisplayName()}.`,
-				['✕', 'Proxy Settings', "Don’t Proxy This Site"],
+				Zotero.getString('proxy_redirect_title', ZOTERO_CONFIG.CLIENT_NAME),
+				Zotero.getString('proxy_redirect_message', [ZOTERO_CONFIG.CLIENT_NAME, uri.host, this.toDisplayName()]),
+				['✕', Zotero.getString('proxy_settings'), Zotero.getString('proxy_dontProxy')],
 				details.tabId
 			).then((response) => {
 				if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");
@@ -951,9 +951,9 @@ Zotero.Proxy.OpenAthensProxy = class extends Zotero.Proxy {
 		Zotero.Proxies.toggleRedirectLoopPrevention(false);
 
 		Zotero.Proxies.showNotification(
-			'New Zotero Proxy Host',
-			`Zotero automatically associated ${host} with a previously defined proxy. Future requests to this site will be redirected through ${this.toDisplayName()}.`,
-			["✕", "Proxy Settings", "Don’t Proxy This Site"],
+			Zotero.getString('proxy_newHost_title'),
+			Zotero.getString('proxy_newHost_message', [ZOTERO_CONFIG.CLIENT_NAME, host, this.toDisplayName()]),
+			["✕", Zotero.getString('proxy_settings'), Zotero.getString('proxy_dontProxy')],
 			details.tabId
 		)
 		.then((response) => {
@@ -977,9 +977,9 @@ Zotero.Proxy.OpenAthensProxy = class extends Zotero.Proxy {
 
 		if (Zotero.Proxies.showRedirectNotification && details.frameId === 0) {
 			Zotero.Proxies.showNotification(
-				'Zotero Proxy Redirection',
-				`Zotero automatically redirected your request to ${uri.host} through the proxy at ${this.toDisplayName()}.`,
-				['✕', 'Proxy Settings', "Don’t Proxy This Site"],
+				Zotero.getString('proxy_redirect_title', ZOTERO_CONFIG.CLIENT_NAME),
+				Zotero.getString('proxy_redirect_message', [ZOTERO_CONFIG.CLIENT_NAME, uri.host, this.toDisplayName()]),
+				['✕', Zotero.getString('proxy_settings'), Zotero.getString('proxy_dontProxy')],
 				details.tabId
 			).then((response) => {
 				if (response == 1) Zotero.Connector_Browser.openPreferences("proxies");

--- a/src/common/ui/ProgressWindow.jsx
+++ b/src/common/ui/ProgressWindow.jsx
@@ -1025,17 +1025,13 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 			contents = <span dangerouslySetInnerHTML={html}/>;
 		}
 		else if (err === "noTranslator") {
-			contents = "No items could be saved because this website "
-				+ "is not supported by any Zotero translator. If Zotero is not open, try opening "
-				+ "it to increase the number of supported sites.";
+			contents = Zotero.getString('progressWindow_error_noTranslator', ZOTERO_CONFIG.CLIENT_NAME);
 		}
 		else if (err === "collectionNotEditable") {
-			contents = "The currently selected collection is not editable. "
-				+ "Please select a different collection in Zotero.";
+			contents = Zotero.getString('progressWindow_error_collectionNotEditable', ZOTERO_CONFIG.CLIENT_NAME);
 		}
 		else if (err === "clientRequired") {
-			contents = "This item could not be saved because Zotero is not open or is unreachable. "
-				+ "Please open Zotero and try again.";
+			contents = Zotero.getString('progressWindow_error_clientRequired', ZOTERO_CONFIG.CLIENT_NAME);
 		}
 		else if (err === "upgradeClient") {
 			let clientName = ZOTERO_CONFIG.CLIENT_NAME;
@@ -1059,10 +1055,9 @@ Zotero.UI.ProgressWindow = class ProgressWindow extends React.PureComponent {
 		}
 		else if (err === "unexpectedError") {
 			let url = "https://www.zotero.org/support/getting_help";
-			contents = <span>
-				An error occurred while saving this item. Try again, and if the issue persists
-				see <a href={url} title={url}>Getting Help</a> for more information.
-			</span>;
+			contents = <span dangerouslySetInnerHTML={{
+				__html: Zotero.getString('progressWindow_error_unexpected', url)
+			}}/>;
 		}
 
 		return (

--- a/src/messages.json
+++ b/src/messages.json
@@ -53,6 +53,84 @@
 	"general_copyToClipboard": {
 		"message": "Copy to Clipboard"
 	},
+	"general_preferences": {
+		"message": "Preferences"
+	},
+
+	"extension_description": {
+		"message": "Save references to Zotero from your web browser"
+	},
+	"extension_defaultTitle": {
+		"message": "Save to Zotero"
+	},
+	"browserAction_status_online": {
+		"message": "$1 is Online",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"browserAction_status_offline": {
+		"message": "$1 is Offline",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"browserAction_saveWebpageWithSnapshot": {
+		"message": "Save to $1 (Web Page with Snapshot)",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"browserAction_saveWebpageWithoutSnapshot": {
+		"message": "Save to $1 (Web Page without Snapshot)",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"browserAction_savePDF": {
+		"message": "Save to $1 (PDF)",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"browserAction_saveWithTranslator": {
+		"message": "Save to $1 ($2)",
+		"description": "$1 is the client name (e.g., Zotero); $2 is the name of a translator"
+	},
+	"browserAction_saving": {
+		"message": "Saving…"
+	},
+	"browserAction_saved": {
+		"message": "Saved!"
+	},
+	"browserAction_saveFailed": {
+		"message": "Saving failed. Is $1 running?",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"contextMenu_saveWithNote": {
+		"message": "Create $1 Item and Note from Selection",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"confirmImport_title": {
+		"message": "$1 - Confirm Import",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"browserAction_incompatibleVersion": {
+		"message": "$1 Connector $2 is incompatible with the running version of the $1 client$3. $1 Connector will continue to operate, but functionality that relies upon the $1 client may be unavailable.\n\nPlease ensure that you have installed the latest version of these components. See https://www.zotero.org/download for more details.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is the Connector version; $3 is the client version in parentheses or an empty string"
+	},
+
+	"expiredBetaBuild_title": {
+		"message": "Build Expired"
+	},
+	"expiredBetaBuild_message": {
+		"message": "This $1 Connector beta build has expired. Please download the latest version from zotero.org.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"contentTypeHandler_addStyle": {
+		"message": "Add citation style to $1?",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"contentTypeHandler_import": {
+		"message": "Import items from $2 into $1?<br/><br/>You can manage automatic file importing in $1 Connector preferences.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is a website hostname"
+	},
+	"contentTypeHandler_import_allow": {
+		"message": "Always allow for this site"
+	},
+	"contentTypeHandler_installingStyle": {
+		"message": "Installing Style"
+	},
 	
 	"itemType_webpage": {
 		"message": "Web Page"
@@ -78,6 +156,12 @@
 	
 	"progressWindow_savingTo": {
 		"message": "Saving to"
+	},
+	"progressWindow_savingToOnlineLibrary": {
+		"message": "Saving to zotero.org"
+	},
+	"progressWindow_saveAsWebpage": {
+		"message": "Save as Webpage"
 	},
 	"progressWindow_detailsBtnView": {
 		"message": "View details"
@@ -151,6 +235,21 @@
 	"progressWindow_error_upgradeClient_latestVersion": {
 		"message": "latest version"
 	},
+	"progressWindow_error_noTranslator": {
+		"message": "No items could be saved because this website is not supported by any $1 translator. If $1 is not open, try opening it to increase the number of supported sites.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"progressWindow_error_collectionNotEditable": {
+		"message": "The currently selected collection is not editable. Please select a different collection in $1.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"progressWindow_error_clientRequired": {
+		"message": "This item could not be saved because $1 is not open or is unreachable. Please open $1 and try again."
+	},
+	"progressWindow_error_unexpected": {
+		"message": "An error occurred while saving this item. Try again, and if the issue persists see <a href=\"$1\" title=\"$1\">Getting Help</a> for more information.",
+		"description": "$1 is the URL of the Getting Help page"
+	},
 	"progressWindow_OA_searching": {
 		"message": "Searching for open-access version…"
 	},
@@ -161,6 +260,261 @@
 	},
 	"itemSelector_pattern": {
 		"message": "Pattern"
+	},
+	"itemSelector_windowTitle": {
+		"message": "$1 Item Selector",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+
+	"preferences_title": {
+		"message": "$1 Connector Preferences",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_general": {
+		"message": "General"
+	},
+	"preferences_proxies": {
+		"message": "Proxies"
+	},
+	"preferences_advanced": {
+		"message": "Advanced"
+	},
+	"preferences_zoteroStatus": {
+		"message": "$1 Status"
+	},
+	"preferences_zoteroStatus_available": {
+		"message": "$1 is currently available."
+	},
+	"preferences_zoteroStatus_unavailable": {
+		"message": "$1 is currently unavailable. If $1 is open, see the <a href=\"$2\">troubleshooting page</a>.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is the URL of the troubleshooting page"
+	},
+	"preferences_zoteroStatus_update": {
+		"message": "Update Status"
+	},
+	"preferences_saveToOnlineLibrary": {
+		"message": "Save to Zotero.org"
+	},
+	"preferences_onlineLibrary_notAuthorized": {
+		"message": "$1 Connector is not currently authorized to save items to zotero.org. You will be prompted for authorization if you try to save items while $1 is not open.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_onlineLibrary_authorized": {
+		"message": "$1 Connector will save items to zotero.org as $2 when $1 is not open.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is a username"
+	},
+	"preferences_onlineLibrary_clearCredentials": {
+		"message": "Clear Credentials"
+	},
+	"preferences_onlineLibrary_automaticSnapshots": {
+		"message": "Automatically take snapshots when saving items"
+	},
+	"preferences_onlineLibrary_downloadAssociatedFiles": {
+		"message": "Automatically download associated PDFs and other files when saving items"
+	},
+	"preferences_onlineLibrary_automaticTags": {
+		"message": "Automatically tag items with keywords and subject headings"
+	},
+	"preferences_fileImporting": {
+		"message": "Automatic File Importing"
+	},
+	"preferences_fileImporting_clientRequired": {
+		"message": "Available when $1 is running"
+	},
+	"preferences_fileImporting_enable": {
+		"message": "Import BibTeX/RIS/Refer files into $1",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_fileImporting_hostnames": {
+		"message": "Enabled Hostnames"
+	},
+	"preferences_fileImporting_remove": {
+		"message": "Remove"
+	},
+	"preferences_reportErrors": {
+		"message": "Report Errors"
+	},
+	"preferences_reportErrors_none": {
+		"message": "No errors have been logged."
+	},
+	"preferences_reportErrors_subtitle": {
+		"message": "The following errors have occurred since the $1 Connector was started:",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_reportErrors_submit": {
+		"message": "Submit Report"
+	},
+	"preferences_debugOutput": {
+		"message": "Debug Output Logging"
+	},
+	"preferences_debugOutput_description": {
+		"message": "Debug output can help $1 developers diagnose problems. Debug logging may slow down your browser, so you should generally leave it disabled unless a $1 developer requests debug output.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_debugOutput_enable": {
+		"message": "Enable Logging"
+	},
+	"preferences_debugOutput_enableAtStartup": {
+		"message": "Enable at Startup"
+	},
+	"preferences_debugOutput_linesLogged": {
+		"message": "$1 lines logged"
+	},
+	"preferences_debugOutput_view": {
+		"message": "View Output"
+	},
+	"preferences_debugOutput_clear": {
+		"message": "Clear Output"
+	},
+	"preferences_debugOutput_submit": {
+		"message": "Submit Output"
+	},
+	"preferences_translators": {
+		"message": "Translators"
+	},
+	"preferences_translators_reportErrors": {
+		"message": "Report broken site translators to zotero.org"
+	},
+	"preferences_translators_reset": {
+		"message": "Reset Translators"
+	},
+	"preferences_translators_resetting": {
+		"message": "Resetting translators…"
+	},
+	"preferences_translators_updated": {
+		"message": "Translators updated!"
+	},
+	"preferences_translators_updateFailed": {
+		"message": "Translator update failed"
+	},
+	"preferences_googleDocs": {
+		"message": "Google Docs Integration"
+	},
+	"preferences_googleDocs_enable": {
+		"message": "Enable Google Docs Integration"
+	},
+	"preferences_googleDocs_shortcut": {
+		"message": "Add/Edit Citation Shortcut"
+	},
+	"preferences_proxySettings": {
+		"message": "Proxy Settings"
+	},
+	"preferences_proxySettings_description": {
+		"message": "$1 will transparently redirect requests through saved proxies. See the <a href=\"$2\">proxy documentation</a> for more information.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is the URL of the proxy documentation"
+	},
+	"preferences_proxySettings_configured": {
+		"message": "Configured Proxies"
+	},
+	"preferences_proxySettings_enable": {
+		"message": "Enable proxy redirection"
+	},
+	"preferences_proxySettings_showRedirectNotification": {
+		"message": "Show a notification when redirecting through a proxy"
+	},
+	"preferences_proxySettings_autoRecognize": {
+		"message": "Automatically detect new proxies"
+	},
+	"preferences_proxySettings_disableByDomain": {
+		"message": "Disable proxy redirection when my domain name contains (available when $1 is running)",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_proxySettings_redirectLoop": {
+		"message": "$1 detected a proxy redirect loop and has temporarily suspended automatic proxy redirection.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"preferences_proxySettings_reenable": {
+		"message": "Re-enable proxy redirection"
+	},
+	"preferences_proxySettings_urlRewritingProxy": {
+		"message": "URL-rewriting proxy (e.g., EZproxy)"
+	},
+	"preferences_proxySettings_openAthens": {
+		"message": "OpenAthens"
+	},
+	"preferences_proxySettings_loginURLScheme": {
+		"message": "Login URL Scheme:"
+	},
+	"preferences_proxySettings_proxiedURLScheme": {
+		"message": "Proxied URL Scheme:"
+	},
+	"preferences_proxySettings_openAthensDomain": {
+		"message": "OpenAthens Redirector Domain:"
+	},
+	"preferences_proxySettings_autoAssociate": {
+		"message": "Automatically associate new hosts"
+	},
+	"preferences_proxySettings_variables": {
+		"message": "You may use the following variables in your proxy schemes:"
+	},
+	"preferences_proxySettings_variableHost": {
+		"message": "%h - The hostname of the proxied site (e.g., www.example.com)"
+	},
+	"preferences_proxySettings_variablePath": {
+		"message": "%p - The path of the proxied page excluding the leading slash (e.g., about/index.html)"
+	},
+	"preferences_proxySettings_variableURL": {
+		"message": "%u - Full encoded proxied site url (e.g. https://www.example.com/about/index.html)"
+	},
+	"preferences_proxySettings_hostnames": {
+		"message": "Hostnames"
+	},
+	"preferences_proxySettings_hostname": {
+		"message": "Hostname:"
+	},
+	"preferences_proxySettings_addHostname": {
+		"message": "Add Hostname"
+	},
+	"preferences_proxySettings_removeHostname": {
+		"message": "Remove Hostname"
+	},
+	"preferences_proxySettings_addProxy": {
+		"message": "Add Proxy"
+	},
+	"preferences_proxySettings_removeProxy": {
+		"message": "Remove Proxy"
+	},
+
+	"proxy_settings": {
+		"message": "Proxy Settings"
+	},
+	"proxy_accept": {
+		"message": "Accept"
+	},
+	"proxy_dontProxy": {
+		"message": "Don’t Proxy This Site"
+	},
+	"proxy_newProxy_title": {
+		"message": "New Proxy"
+	},
+	"proxy_newProxy_message": {
+		"message": "$1 detected that you are accessing $2 through a proxy. Would you like to automatically redirect future requests to $2 through $3?",
+		"description": "$1 is the client name (e.g., Zotero); $2 is a website hostname; $3 is a proxy name"
+	},
+	"proxy_addProxy_title": {
+		"message": "Only add proxies linked from your library, school, or corporate website"
+	},
+	"proxy_addProxy_message": {
+		"message": "Adding other proxies allows malicious sites to masquerade as sites you trust.<br/><br/>Adding this proxy will allow $1 to recognize items from proxied pages and will automatically redirect future requests to $2 through $3.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is a website hostname; $3 is a proxy name"
+	},
+	"proxy_addProxy": {
+		"message": "Add Proxy"
+	},
+	"proxy_newHost_title": {
+		"message": "New Proxy Host"
+	},
+	"proxy_newHost_message": {
+		"message": "$1 automatically associated $2 with a previously defined proxy. Future requests to this site will be redirected through $3.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is a website hostname; $3 is a proxy name"
+	},
+	"proxy_redirect_title": {
+		"message": "$1 Proxy Redirection",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"proxy_redirect_message": {
+		"message": "$1 automatically redirected your request to $2 through the proxy at $3.",
+		"description": "$1 is the client name (e.g., Zotero); $2 is a website hostname; $3 is a proxy name"
 	},
 	
 	"extensionIsDisabled": {

--- a/src/messages.json
+++ b/src/messages.json
@@ -595,6 +595,17 @@
 	"integration_googleDocs_updating": {
 		"message": "$1 is updating your document."
 	},
+	"integration_googleDocs_tabNotActive": {
+		"message": "$1 needs the Google Docs tab to stay active for the current operation. Please do not switch away from the browser until the operation is complete.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
+	"integration_googleDocs_uiChanged": {
+		"message": "Google Docs has changed in a way that affects Zotero integration. Please submit a <a href=\"https://www.zotero.org/support/reporting_problems\">Report ID</a> from the Zotero Connector on the <a href=\"https://forums.zotero.org\">Zotero Forums</a>."
+	},
+	"integration_googleDocs_unexpectedError": {
+		"message": "An unexpected error occurred while working with your document. Please try again. If the problem persists, restart your browser and $1.",
+		"description": "$1 is the client name (e.g., Zotero)"
+	},
 	"integration_googleDocs_docxAlert": {
 		"message": "$1 integration is not available when editing Microsoft Word .docx files directly in Google Docs. Choose File → Save as Google Docs to enable this functionality.<br/><br/>If you want to transfer a Word document with $1 citations to Google Docs, see <a href=\"https://www.zotero.org/support/kb/moving_documents_between_word_processors\">Moving Documents Between Word Processors</a>."
 	},

--- a/src/safari/i18n.js
+++ b/src/safari/i18n.js
@@ -43,18 +43,25 @@ Zotero.i18n = {
 
 	_loadStrings: async function() {
 		let ui = browser.i18n.getUILanguage() || 'en';
+		let fallback = {};
+		try {
+			let resp = await fetch(browser.runtime.getURL('_locales/en/messages.json'));
+			if (resp.ok) fallback = await resp.json();
+		} catch (e) {}
+
 		let tried = [];
-		// Try the full locale, then language-only, then English. Locale folder names mirror the
-		// _locales/ directory (mostly 2-letter, plus a few like pt-PT/zh-TW).
-		for (let code of [ui, ui.replace('-', '_'), ui.split(/[-_]/)[0], 'en']) {
-			if (!code || tried.includes(code)) continue;
+		// Try the full locale, then language-only. Locale folder names mirror the _locales/
+		// directory (mostly 2-letter, plus a few like pt-PT/zh-TW). Merge with English so new
+		// strings remain available while translations are being updated.
+		for (let code of [ui, ui.replace('-', '_'), ui.split(/[-_]/)[0]]) {
+			if (!code || code == 'en' || tried.includes(code)) continue;
 			tried.push(code);
 			try {
 				let resp = await fetch(browser.runtime.getURL(`_locales/${code}/messages.json`));
-				if (resp.ok) return await resp.json();
+				if (resp.ok) return Object.assign(fallback, await resp.json());
 			} catch (e) {}
 		}
-		return {};
+		return fallback;
 	},
 
 	// Background-only message handler; injected pages call this (via messaging) to get the strings


### PR DESCRIPTION
Localize the rest of the strings. Closes #58

Localize preferences, browser actions and menus, import/save
dialogs, progress errors, proxy prompts, version warnings,
and extension metadata.

Add contextual accessible names for proxy controls

Preserve Safari fallback behavior for newly added strings.