### PR TITLE
Fix attachment cookie handling with Firefox First-Party Isolation

### DIFF
--- a/src/browserExt/background.js
+++ b/src/browserExt/background.js
@@ -109,21 +109,72 @@ Zotero.Connector_Browser = new function() {
 	}
 
 	/**
-	 * Gets cookies from the store associated with a tab. In Safari, the default cookie store
-	 * may differ from the store used by browser tabs, so it must be resolved at runtime. If
-	 * no tab is provided, the active tab in the current window is used.
+	 * Gets cookies from the store associated with a tab. Firefox container tabs and Safari tabs
+	 * may use a different store from the extension default, so it must be resolved at runtime.
+	 * In Safari, if no tab is provided, the active tab in the current window is used.
 	 *
 	 * @param {Object} details
-	 * @param {Number} tabId
+	 * @param {Number|Object} tabOrId A snapshot of the originating tab is preferred so that a
+	 * navigation while saving cannot change the cookie context.
 	 * @return {Promise<browser.cookies.Cookie[]>}
 	 */
-	this.getAllCookies = async function(details, tabId=null) {
+	this.getAllCookies = async function(details, tabOrId=null) {
 		details = {...details};
+		let tab = typeof tabOrId === 'object' ? tabOrId : null;
+		let tabId = tab?.id ?? tabOrId;
+		if (Zotero.isFirefox && tabId != null && !tab) {
+			tab = await browser.tabs.get(tabId);
+		}
+		if (Zotero.isFirefox && !details.storeId) {
+			if (tab?.cookieStoreId) {
+				details.storeId = tab.cookieStoreId;
+			}
+		}
+		if (Zotero.isFirefox
+				&& !Object.prototype.hasOwnProperty.call(details, 'firstPartyDomain')) {
+			try {
+				return await browser.cookies.getAll(details);
+			}
+			catch (e) {
+				// With legacy First-Party Isolation enabled, Firefox requires a
+				// firstPartyDomain for every cookies.getAll() call. Querying with null
+				// returns all jars, so only expose cookies from the jar associated with
+				// the originating top-level tab.
+				// Without an originating tab, the correct FPI jar is unknowable. Do
+				// not guess based on whichever tab happens to be active.
+				if (!tab?.url) throw e;
+
+				let hostname;
+				try {
+					hostname = new URL(tab.url).hostname;
+				}
+				catch (urlError) {
+					throw e;
+				}
+				if (!hostname) throw e;
+
+				let cookies = await browser.cookies.getAll({
+					...details,
+					firstPartyDomain: null,
+				});
+				let firstPartyDomain = cookies
+					.map(cookie => cookie.firstPartyDomain)
+					.filter(domain => domain
+						&& (hostname === domain || hostname.endsWith(`.${domain}`)))
+					.sort((a, b) => b.length - a.length)[0];
+				if (!firstPartyDomain) return [];
+				return browser.cookies.getAll({
+					...details,
+					firstPartyDomain,
+				});
+			}
+		}
+
 		if (!Zotero.isSafari || details.storeId) {
 			return browser.cookies.getAll(details);
 		}
 
-		if (tabId === null) {
+		if (tabId == null) {
 			let tabs = await browser.tabs.query({active: true, currentWindow: true});
 			tabId = tabs[0]?.id;
 		}

--- a/src/browserExt/webRequestIntercept.js
+++ b/src/browserExt/webRequestIntercept.js
@@ -177,11 +177,17 @@ Zotero.WebRequestIntercept = {
 		const requestHeaders = headers.map((headerObj) => {
 			if (headerObj.name.toLowerCase() === 'cookie') {
 				// Chrome bug: 'append' op is checked against an allow-list and fails if header name is not lowercase
-				return { header: headerObj.name.toLowerCase(), value: headerObj.value, operation: 'append' };
+				// FPI cookies replace the background request's native jar. Partitioned cookies
+				// are appended to the ordinary cookies the browser sends itself.
+				let operation = headerObj.operation || 'append';
+				return { header: headerObj.name.toLowerCase(), value: headerObj.value, operation };
 			}
 			return { header: headerObj.name, value: headerObj.value, operation: 'set' }
 		});
 		const ruleID = Math.floor(Math.random() * 100000);
+		let requestURL = new URL(url);
+		requestURL.hash = '';
+		let regexFilter = `^${requestURL.href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`;
 		const rules = [{
 			id: ruleID,
 			action: {
@@ -191,6 +197,8 @@ Zotero.WebRequestIntercept = {
 			condition: {
 				resourceTypes: ['xmlhttprequest'],
 				initiatorDomains: [new URL(browser.runtime.getURL('')).hostname],
+				// Do not expose special headers to concurrent extension requests or redirects.
+				regexFilter,
 			}
 		}];
 		// Keep the service worker alive while the rule is active

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -220,6 +220,9 @@ Zotero.HTTP = new function() {
 			let replaceHeaders = HEADERS_SPECIAL_HANDLING.filter(header => !!options.headers[header])
 				.map(header => {
 					const val = { name: header, value: options.headers[header] }
+					if (header === 'Cookie' && options.cookieHeaderOperation) {
+						val.operation = options.cookieHeaderOperation;
+					}
 					delete options.headers['User-Agent'];
 					return val;
 				});
@@ -357,6 +360,9 @@ Zotero.HTTP = new function() {
 			let replaceHeaders = HEADERS_SPECIAL_HANDLING.filter(header => !!options.headers[header])
 				.map(header => {
 					const val = { name: header, value: options.headers[header] }
+					if (header === 'Cookie' && options.cookieHeaderOperation) {
+						val.operation = options.cookieHeaderOperation;
+					}
 					delete options.headers[header];
 					return val;
 				});

--- a/src/common/itemSaver_background.js
+++ b/src/common/itemSaver_background.js
@@ -208,20 +208,75 @@ Zotero.ItemSaver._fetchAttachment = async function(attachment, tab, attemptBotPr
 		cookies = await Zotero.Connector_Browser.getAllCookies({
 			url: attachment.url,
 			partitionKey: {},
-		}, tab?.id);
+		}, tab);
 	} catch (e) {
 		// Unavailable with Chrome 118 and below. Last supported version on Win 7/8 is Chrome 109.
-		Zotero.debug(`Error getting cookies for ${attachment.url} with partitionKey.`);
-		cookies = await Zotero.Connector_Browser.getAllCookies({
-			url: attachment.url,
-		}, tab?.id);
+		Zotero.debug(`Error getting cookies for ${attachment.url} with partitionKey: ${e}`);
+		try {
+			cookies = await Zotero.Connector_Browser.getAllCookies({
+				url: attachment.url,
+			}, tab);
+		}
+		catch (cookieError) {
+			Zotero.debug(`Unable to enumerate cookies for ${attachment.url}; continuing without a manually constructed Cookie header: ${cookieError}`);
+			cookies = [];
+		}
 	}
-	// Chromium and Firefox will send cookies, but Chrome currently ignores those with partitionKey.
-	// Cloudflare clearance cookies and potentially others in the future are set with a partitionKey.
+	// Chromium and Firefox send ordinary cookies themselves, but Chrome currently ignores cookies
+	// with partitionKey. Firefox background requests also cannot select the originating tab's legacy
+	// FPI jar. Add only partitioned cookies or FPI cookies selected for the originating tab above.
+	// Cloudflare clearance cookies and potentially others in the future are partitioned.
 	// There's a bug filed for this at https://issues.chromium.org/issues/458071621
-	cookies = cookies.filter(c => c.partitionKey);
-	options.headers = {
-		"Cookie": cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ')
+	let topLevelURL;
+	let attachmentURL;
+	try {
+		topLevelURL = new URL(tab?.url);
+		attachmentURL = new URL(attachment.url);
+	}
+	catch (e) {}
+	cookies = cookies.filter(cookie => {
+		if (!topLevelURL || !attachmentURL) return false;
+
+		let contextDomain;
+		if (cookie.firstPartyDomain) {
+			contextDomain = cookie.firstPartyDomain;
+			if (topLevelURL.hostname !== contextDomain
+					&& !topLevelURL.hostname.endsWith(`.${contextDomain}`)) {
+				return false;
+			}
+		}
+		else if (cookie.partitionKey?.topLevelSite) {
+			let partitionURL;
+			try {
+				partitionURL = new URL(cookie.partitionKey.topLevelSite);
+			}
+			catch (e) {
+				return false;
+			}
+			contextDomain = partitionURL.hostname;
+			if (partitionURL.protocol !== topLevelURL.protocol
+					|| (topLevelURL.hostname !== contextDomain
+						&& !topLevelURL.hostname.endsWith(`.${contextDomain}`))) {
+				return false;
+			}
+		}
+		else {
+			return false;
+		}
+
+		// Constructing Cookie manually bypasses the browser's SameSite selection, so
+		// reproduce its cross-site restriction before adding anything to the header.
+		let sameSite = attachmentURL.hostname === contextDomain
+			|| attachmentURL.hostname.endsWith(`.${contextDomain}`);
+		return sameSite || (cookie.sameSite === 'no_restriction' && cookie.secure);
+	});
+	if (cookies.length) {
+		options.headers = {
+			"Cookie": cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ')
+		}
+		options.cookieHeaderOperation = cookies.some(cookie => cookie.firstPartyDomain)
+			? 'set'
+			: 'append';
 	}
 	options.referrer = attachment.referrer;
 
@@ -256,14 +311,14 @@ Zotero.ItemSaver._fetchAttachment = async function(attachment, tab, attemptBotPr
 	try {
 		let pdfURL = await Zotero.BotBypass.passJSDetectionViaHiddenIframe(attachment.url, tab);
 		attachment.url = pdfURL;
-		return await this._fetchAttachment(attachment, false);
+		return await this._fetchAttachment(attachment, tab, false);
 	}
 	catch (e) {
 		Zotero.debug(`Failed to pass JS bot detection via hidden iframe for URL: ${attachment.url}`);
 		Zotero.debug(e);
 		let pdfURL = await Zotero.BotBypass.passJSDetectionViaWindowPrompt(originalUrl, tab);
 		attachment.url = pdfURL;
-		return this._fetchAttachment(attachment, false);
+		return this._fetchAttachment(attachment, tab, false);
 	}
 };
 

--- a/test/support/puppeteerSetup.mjs
+++ b/test/support/puppeteerSetup.mjs
@@ -218,4 +218,4 @@ export async function mochaGlobalTeardown() {
 	else if (noQuit) {
 		console.log('Skipping browser close due to NO_QUIT=true.');
 	}
-} 
+}

--- a/test/tests/backgroundTest.mjs
+++ b/test/tests/backgroundTest.mjs
@@ -29,6 +29,130 @@ describe('Connector_Browser', function() {
 	var tab = new Tab();
 
 	describe('#getAllCookies()', function() {
+		it('uses only the Firefox FPI cookie jar associated with the tab', async function() {
+			let result = await background(async function() {
+				let isFirefox = Zotero.isFirefox;
+				Zotero.isFirefox = true;
+				sinon.stub(browser.tabs, 'get').resolves({
+					id: 123,
+					url: 'https://reader.example.com/article',
+					cookieStoreId: 'firefox-container-1',
+				});
+				sinon.stub(browser.cookies, 'getAll');
+				browser.cookies.getAll.onFirstCall().rejects(new Error(
+					"First-Party Isolation is enabled, but the required 'firstPartyDomain' attribute was not set."
+				));
+				browser.cookies.getAll.onSecondCall().resolves([
+					{name: 'correct', firstPartyDomain: 'example.com'},
+					{name: 'unrelated', firstPartyDomain: 'unrelated.example'},
+					{name: 'unpartitioned', firstPartyDomain: ''},
+				]);
+				browser.cookies.getAll.onThirdCall().resolves([
+					{name: 'correct', firstPartyDomain: 'example.com'},
+				]);
+				try {
+					let cookies = await Zotero.Connector_Browser.getAllCookies({
+						url: 'https://attachments.example.net/file.pdf',
+						partitionKey: {},
+					}, {
+						id: 123,
+						url: 'https://reader.example.com/article',
+						cookieStoreId: 'firefox-container-1',
+					});
+					return {
+						cookies,
+						secondCallDetails: browser.cookies.getAll.secondCall.args[0],
+						thirdCallDetails: browser.cookies.getAll.thirdCall.args[0],
+						tabsGetCalled: browser.tabs.get.called,
+					};
+				}
+				finally {
+					browser.tabs.get.restore();
+					browser.cookies.getAll.restore();
+					Zotero.isFirefox = isFirefox;
+				}
+			});
+
+			assert.deepEqual(result.cookies, [
+				{name: 'correct', firstPartyDomain: 'example.com'}
+			]);
+			assert.deepEqual(result.secondCallDetails, {
+				url: 'https://attachments.example.net/file.pdf',
+				partitionKey: {},
+				storeId: 'firefox-container-1',
+				firstPartyDomain: null,
+			});
+			assert.deepEqual(result.thirdCallDetails, {
+				url: 'https://attachments.example.net/file.pdf',
+				partitionKey: {},
+				storeId: 'firefox-container-1',
+				firstPartyDomain: 'example.com',
+			});
+			assert.isFalse(result.tabsGetCalled);
+		});
+
+		it('returns no Firefox FPI cookies when the tab jar cannot be identified', async function() {
+			let cookies = await background(async function() {
+				let isFirefox = Zotero.isFirefox;
+				Zotero.isFirefox = true;
+				sinon.stub(browser.tabs, 'get').resolves({
+					id: 123,
+					url: 'https://example.com/article'
+				});
+				sinon.stub(browser.cookies, 'getAll');
+				browser.cookies.getAll.onFirstCall().rejects(new Error(
+					"First-Party Isolation is enabled, but the required 'firstPartyDomain' attribute was not set."
+				));
+				browser.cookies.getAll.onSecondCall().resolves([
+					{name: 'unrelated', firstPartyDomain: 'unrelated.example'},
+				]);
+				try {
+					return await Zotero.Connector_Browser.getAllCookies({
+						url: 'https://attachments.example.net/file.pdf',
+					}, {
+						id: 123,
+						url: 'https://example.com/article',
+					});
+				}
+				finally {
+					browser.tabs.get.restore();
+					browser.cookies.getAll.restore();
+					Zotero.isFirefox = isFirefox;
+				}
+			});
+
+			assert.deepEqual(cookies, []);
+		});
+
+		it('does not query all Firefox FPI jars without an originating tab', async function() {
+			let result = await background(async function() {
+				let isFirefox = Zotero.isFirefox;
+				Zotero.isFirefox = true;
+				sinon.stub(browser.cookies, 'getAll').rejects(new Error(
+					"First-Party Isolation is enabled, but the required 'firstPartyDomain' attribute was not set."
+				));
+				try {
+					let error;
+					try {
+						await Zotero.Connector_Browser.getAllCookies({
+							url: 'https://attachments.example.net/file.pdf',
+						});
+					}
+					catch (e) {
+						error = e.message;
+					}
+					return {error, callCount: browser.cookies.getAll.callCount};
+				}
+				finally {
+					browser.cookies.getAll.restore();
+					Zotero.isFirefox = isFirefox;
+				}
+			});
+
+			assert.include(result.error, 'firstPartyDomain');
+			assert.equal(result.callCount, 1);
+		});
+
 		it('uses the Safari cookie store associated with the tab', async function() {
 			let details = await background(async function() {
 				let isSafari = Zotero.isSafari;

--- a/test/tests/itemSaver_backgroundTest.mjs
+++ b/test/tests/itemSaver_backgroundTest.mjs
@@ -35,7 +35,7 @@ describe("ItemSaver Background", function() {
 				mimeType: 'application/pdf',
 				referrer: 'https://example.com'
 			};
-			mockTab = { id: 123 };
+			mockTab = { id: 123, url: 'https://example.com/article' };
 
 			// Set up default stubs
 			await background(function() {
@@ -89,6 +89,119 @@ describe("ItemSaver Background", function() {
 				}, attachment, mockTab);
 				
 				assert.equal(result, 1024);
+			});
+
+			it('should fall back when partitionKey is unsupported', async function() {
+				const result = await background(async function(attachment, mockTab) {
+					browser.cookies.getAll.onFirstCall().rejects(new Error('Unexpected property partitionKey'));
+					browser.cookies.getAll.onSecondCall().resolves([
+						{name: 'ordinary', value: 'sent-by-browser'},
+					]);
+					await Zotero.ItemSaver._fetchAttachment(attachment, mockTab);
+					return {
+						calls: browser.cookies.getAll.getCalls().map(call => call.args[0]),
+						hasCookieHeader: !!Zotero.HTTP.request.firstCall.args[2].headers?.Cookie,
+						cookieOperation: Zotero.HTTP.request.firstCall.args[2].cookieHeaderOperation,
+					};
+				}, attachment, mockTab);
+
+				assert.deepEqual(result.calls, [
+					{url: attachment.url, partitionKey: {}},
+					{url: attachment.url},
+				]);
+				assert.isFalse(result.hasCookieHeader);
+				assert.isUndefined(result.cookieOperation);
+			});
+
+			it('should append cookies from the matching partition', async function() {
+				const result = await background(async function(attachment, mockTab) {
+					browser.cookies.getAll.resolves([{
+						name: 'clearance',
+						value: 'allowed',
+						partitionKey: {topLevelSite: 'https://example.com'},
+					}]);
+					await Zotero.ItemSaver._fetchAttachment(attachment, mockTab);
+					return {
+						cookieHeader: Zotero.HTTP.request.firstCall.args[2].headers.Cookie,
+						cookieOperation: Zotero.HTTP.request.firstCall.args[2].cookieHeaderOperation,
+					};
+				}, attachment, mockTab);
+
+				assert.equal(result.cookieHeader, 'clearance=allowed');
+				assert.equal(result.cookieOperation, 'append');
+			});
+
+			it('should send cookies from the selected Firefox FPI jar', async function() {
+				const result = await background(async function(attachment, mockTab) {
+					browser.cookies.getAll.resolves([
+						{name: 'session', value: 'authenticated', firstPartyDomain: 'example.com'},
+					]);
+					await Zotero.ItemSaver._fetchAttachment(attachment, mockTab);
+					return {
+						cookieHeader: Zotero.HTTP.request.firstCall.args[2].headers.Cookie,
+						cookieOperation: Zotero.HTTP.request.firstCall.args[2].cookieHeaderOperation,
+					};
+				}, attachment, mockTab);
+
+				assert.equal(result.cookieHeader, 'session=authenticated');
+				assert.equal(result.cookieOperation, 'set');
+			});
+
+			it('should not combine cookies from unrelated partition keys', async function() {
+				const cookieHeader = await background(async function(attachment, mockTab) {
+					browser.cookies.getAll.resolves([
+						{
+							name: 'correct',
+							value: 'allowed',
+							partitionKey: {topLevelSite: 'https://example.com'},
+						},
+						{
+							name: 'unrelated',
+							value: 'blocked',
+							partitionKey: {topLevelSite: 'https://unrelated.example'},
+						},
+					]);
+					await Zotero.ItemSaver._fetchAttachment(attachment, mockTab);
+					return Zotero.HTTP.request.firstCall.args[2].headers.Cookie;
+				}, attachment, mockTab);
+
+				assert.equal(cookieHeader, 'correct=allowed');
+			});
+
+			it('should preserve SameSite restrictions for cross-site FPI cookies', async function() {
+				attachment.url = 'https://attachments.example.net/file.pdf';
+				const cookieHeader = await background(async function(attachment, mockTab) {
+					browser.cookies.getAll.resolves([
+						{
+							name: 'strict', value: 'blocked', firstPartyDomain: 'example.com',
+							sameSite: 'strict', secure: true,
+						},
+						{
+							name: 'crossSite', value: 'allowed', firstPartyDomain: 'example.com',
+							sameSite: 'no_restriction', secure: true,
+						},
+					]);
+					await Zotero.ItemSaver._fetchAttachment(attachment, mockTab);
+					return Zotero.HTTP.request.firstCall.args[2].headers.Cookie;
+				}, attachment, mockTab);
+
+				assert.equal(cookieHeader, 'crossSite=allowed');
+			});
+
+			it('should continue without a Cookie header when both cookie lookups fail', async function() {
+				const result = await background(async function(attachment, mockTab) {
+					browser.cookies.getAll.rejects(new Error('Cookie API unavailable'));
+					let response = await Zotero.ItemSaver._fetchAttachment(attachment, mockTab);
+					return {
+						byteLength: response.byteLength,
+						cookieCalls: browser.cookies.getAll.callCount,
+						hasCookieHeader: !!Zotero.HTTP.request.firstCall.args[2].headers?.Cookie,
+					};
+				}, attachment, mockTab);
+
+				assert.equal(result.byteLength, 1024);
+				assert.equal(result.cookieCalls, 2);
+				assert.isFalse(result.hasCookieHeader);
 			});
 		});
 

--- a/test/tests/webRequestInterceptTest.mjs
+++ b/test/tests/webRequestInterceptTest.mjs
@@ -26,6 +26,36 @@
 import { background } from '../support/utils.mjs';
 
 describe("WebRequestIntercept", function() {
+	describe('#replaceHeadersDNR()', function() {
+		it('scopes rules to the exact URL and applies the requested Cookie operation', async function() {
+			let rule = await background(async function() {
+				sinon.stub(browser.declarativeNetRequest, 'updateSessionRules').resolves();
+				sinon.stub(Zotero.Connector_Browser, 'setKeepServiceWorkerAlive');
+				sinon.stub(globalThis, 'setTimeout');
+				try {
+					await Zotero.WebRequestIntercept.replaceHeadersDNR(
+						'https://example.com/file.pdf?token=a.b#fragment',
+						[{name: 'Cookie', value: 'session=secret', operation: 'set'}]
+					);
+					return browser.declarativeNetRequest.updateSessionRules.firstCall.args[0].addRules[0];
+				}
+				finally {
+					browser.declarativeNetRequest.updateSessionRules.restore();
+					Zotero.Connector_Browser.setKeepServiceWorkerAlive.restore();
+					globalThis.setTimeout.restore();
+				}
+			});
+
+			assert.equal(rule.condition.regexFilter,
+				'^https://example\\.com/file\\.pdf\\?token=a\\.b$');
+			assert.deepEqual(rule.action.requestHeaders, [{
+				header: 'cookie',
+				value: 'session=secret',
+				operation: 'set',
+			}]);
+		});
+	});
+
 	describe('#offerSavingPDFInFrame()', function() {
 		it('calls Zotero.Connector_Browser.onPDFFrame when pdf frame loads', async function () {
 			let args = await background(function() {


### PR DESCRIPTION
This PR:

1. Resolve cookies using the originating tab’s Firefox FPI and container context, and avoid combining cookies from unrelated partitions.

2. Gracefully continue attachment downloads when cookie enumeration fails, scope temporary Cookie headers to the exact request URL, and preserve browser cookie semantics when injecting contextual cookies.

3. Also retain compatibility with older Chromium versions that reject partitionKey and preserve the tab context during bot-bypass retries.

Fixes #226 

The code changes are proposed by a LLM and manually reviewed by me line-by-line. Manual testing shows that this PR fixes PDF saving issues on Firefox with FPI enabled.